### PR TITLE
Refactor parsing/lexing

### DIFF
--- a/cmd/schemalex/schemalex.go
+++ b/cmd/schemalex/schemalex.go
@@ -9,28 +9,17 @@ import (
 	"github.com/schemalex/schemalex/diff"
 )
 
-var (
-	errorMarker  = flag.String("error-marker", "___", "marker of parse error position")
-	errorContext = flag.Int("error-context", 20, "before, after context position of parse error")
-)
-
 func main() {
-	flag.Parse()
-	args := flag.Args()
-
-	if len(args) != 2 {
+	if len(os.Args) != 3 {
 		log.Fatalf("should call schemalex <options> /path/to/before /path/to/after")
 	}
 
-	if err := _main(args[0], args[1]); err != nil {
+	if err := _main(os.Args[1], os.Args[2]); err != nil {
 		log.Fatal(err)
 	}
 }
 
 func _main(before, after string) error {
 	p := schemalex.New()
-	p.ErrorMarker = *errorMarker
-	p.ErrorContext = *errorContext
-
 	return diff.Files(os.Stderr, before, after, diff.WithTransaction(true), diff.WithParser(p))
 }

--- a/cmd/schemalex/schemalex.go
+++ b/cmd/schemalex/schemalex.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
 

--- a/cmd/schemalex/schemalex.go
+++ b/cmd/schemalex/schemalex.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	if len(os.Args) != 3 {
-		log.Fatalf("should call schemalex <options> /path/to/before /path/to/after")
+		log.Fatalf("should call schemalex /path/to/before /path/to/after")
 	}
 
 	if err := _main(os.Args[1], os.Args[2]); err != nil {

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -37,8 +37,8 @@ func TestDiff(t *testing.T) {
 		// add column
 		{
 			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL );",
-			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL, `c` VARCHAR (20) NOT NULL DEFAULT 'xxx' );",
-			Expect: "ALTER TABLE `fuga` ADD COLUMN `c` VARCHAR (20) NOT NULL DEFAULT 'xxx';",
+			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL, `c` VARCHAR (20) NOT NULL DEFAULT 'xxx');",
+			Expect: "ALTER TABLE `fuga` ADD COLUMN `c` VARCHAR (20) NOT NULL DEFAULT \"xxx\";",
 		},
 		// change column
 		{

--- a/errors.go
+++ b/errors.go
@@ -44,7 +44,7 @@ func (e ParseError) Error() string {
 	if e.eof {
 		buf.WriteString(" (at EOF)")
 	}
-	buf.WriteByte('\n')
+	buf.WriteString("\n    ")
 	buf.WriteString(e.context)
 	return buf.String()
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,79 @@
+package schemalex
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// ParseError is returned from the various `Parse` methods when an
+// invalid or unsupported SQL is found. When stringified, the result
+// will look something like this:
+//
+//    parse error: expected RPAREN at line 3 column 14
+//	  "CREATE TABLE foo " <---- AROUND HERE
+type ParseError struct {
+	context string
+	line    int
+	col     int
+	message string
+	eof     bool
+}
+
+// Line returns the line number where the error was encountered
+func (e ParseError) Line() int { return e.line }
+
+// Col returns the column number where the error was encountered
+func (e ParseError) Col() int { return e.col }
+
+// EOF returns true if the error was encountered at EOF
+func (e ParseError) EOF() bool { return e.eof }
+
+// Message returns the actual error message
+func (e ParseError) Message() string { return e.message }
+
+// Error returns the formatted string representation of this parse error.
+func (e ParseError) Error() string {
+	var buf bytes.Buffer
+	buf.WriteString("parse error: ")
+	buf.WriteString(e.message)
+	buf.WriteString(" at line ")
+	buf.WriteString(strconv.Itoa(e.line))
+	buf.WriteString(" column ")
+	buf.WriteString(strconv.Itoa(e.col))
+	if e.eof {
+		buf.WriteString(" (at EOF)")
+	}
+	buf.WriteByte('\n')
+	buf.WriteString(e.context)
+	return buf.String()
+}
+
+func newParseError(ctx *parseCtx, t *Token, msg string, args ...interface{}) error {
+	if len(args) > 0 {
+		msg = fmt.Sprintf(msg, args...)
+	}
+
+	// find the closest newline before t.Pos
+	var ctxbegin int
+	if i := bytes.LastIndexByte(ctx.input[:t.Pos], '\n'); i > 0 {
+		if len(ctx.input)-1 > i {
+			ctxbegin = i + 1
+		}
+	}
+
+	// if this is more than 40 chars from t.Pos, truncate it
+	if t.Pos-ctxbegin > 40 {
+		ctxbegin = t.Pos - 40
+	}
+
+	// We're going to append a marker here
+
+	return &ParseError{
+		context: fmt.Sprintf(`"%s" <---- AROUND HERE`, ctx.input[ctxbegin:t.Pos]),
+		line:    t.Line,
+		col:     t.Col,
+		eof:     t.EOF,
+		message: msg,
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -11,7 +11,7 @@ import (
 // will look something like this:
 //
 //    parse error: expected RPAREN at line 3 column 14
-//	  "CREATE TABLE foo " <---- AROUND HERE
+//	      "CREATE TABLE foo " <---- AROUND HERE
 type ParseError struct {
 	context string
 	line    int

--- a/errors.go
+++ b/errors.go
@@ -13,12 +13,16 @@ import (
 //    parse error: expected RPAREN at line 3 column 14
 //	      "CREATE TABLE foo " <---- AROUND HERE
 type ParseError struct {
+	file    string
 	context string
 	line    int
 	col     int
 	message string
 	eof     bool
 }
+
+// File returns the file name (if applicable) where the error was encountered
+func (e ParseError) File() string { return e.file }
 
 // Line returns the line number where the error was encountered
 func (e ParseError) Line() int { return e.line }
@@ -37,6 +41,10 @@ func (e ParseError) Error() string {
 	var buf bytes.Buffer
 	buf.WriteString("parse error: ")
 	buf.WriteString(e.message)
+	if f := e.file; len(f) > 0 {
+		buf.WriteString(" in file ")
+		buf.WriteString(f)
+	}
 	buf.WriteString(" at line ")
 	buf.WriteString(strconv.Itoa(e.line))
 	buf.WriteString(" column ")

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,14 @@
-hash: 653e5e93d2b773a793f9fb9a17855b4d081f35f1cbe1913e3c78bbeaae07e646
-updated: 2017-01-06T14:15:49.579928471+09:00
+hash: acd75c6bb27f02d764ba99c050695601a534267aba54c34ee1e5ae0a926c8de7
+updated: 2017-01-06T20:57:01.442243996+09:00
 imports:
 - name: github.com/deckarep/golang-set
   version: 0c62f01318f81fb34e5ea393d2ec62141e9715e9
 - name: github.com/pkg/errors
   version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
+- name: golang.org/x/net
+  version: 905989bd20b7c354fd28a61074eed1c8f49ebc89
+  subpackages:
+  - context
 testImports:
 - name: github.com/davecgh/go-spew
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,9 @@ package: github.com/schemalex/schemalex
 import:
 - package: github.com/deckarep/golang-set
 - package: github.com/pkg/errors
+- package: golang.org/x/net
+  subpackages:
+  - context
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/internal/cmd/gentokens/main.go
+++ b/internal/cmd/gentokens/main.go
@@ -33,6 +33,10 @@ func _main() error {
 	buf.WriteString("\ntype Token struct {")
 	buf.WriteString("\nType TokenType")
 	buf.WriteString("\nValue string")
+	buf.WriteString("\nPos int")
+	buf.WriteString("\nLine int")
+	buf.WriteString("\nCol int")
+	buf.WriteString("\nEOF bool")
 	buf.WriteString("\n}")
 
 	buf.WriteString("\n\nfunc NewToken(t TokenType, v string) *Token {")

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -46,6 +46,10 @@ func IsIgnorable(err error) bool {
 	return false
 }
 
+func New(s string) error {
+	return daverr.New(s)
+}
+
 func Wrap(err error, s string) error {
 	return daverr.Wrap(err, s)
 }

--- a/lexer.go
+++ b/lexer.go
@@ -2,11 +2,11 @@ package schemalex
 
 import (
 	"bytes"
-	"errors"
 	"strings"
 	"unicode/utf8"
 
 	"golang.org/x/net/context"
+	"github.com/schemalex/schemalex/internal/errors"
 )
 
 const eof = rune(0)

--- a/lexer.go
+++ b/lexer.go
@@ -110,8 +110,8 @@ OUTER:
 			l.emit(ctx, SPACE)
 			continue OUTER
 		case isLetter(r):
-			l.runIdent()
-			t, s := l.runIdent(), l.str()
+			t := l.runIdent()
+			s := l.str()
 			if typ, ok := keywordIdentMap[strings.ToUpper(s)]; ok {
 				t = typ
 			}

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -4,106 +4,90 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"golang.org/x/net/context"
 )
 
-func TestRead(t *testing.T) {
+func TestLexToken(t *testing.T) {
 	type Spec struct {
-		input     string
-		str       string
-		TokenType TokenType
+		input string
+		token Token
 	}
 
 	specs := []Spec{
 		// number
 		{
-			input:     "123",
-			str:       "123",
-			TokenType: NUMBER,
+			input: "123",
+			token: Token{Value: "123", Type: NUMBER},
 		},
 		{
-			input:     ".2",
-			str:       ".2",
-			TokenType: NUMBER,
+			input: ".2",
+			token: Token{Value: ".2", Type: NUMBER},
 		},
 		{
-			input:     "3.4",
-			str:       "3.4",
-			TokenType: NUMBER,
+			input: "3.4",
+			token: Token{Value: "3.4", Type: NUMBER},
 		},
 		{
-			input:     "-5",
-			str:       "-5",
-			TokenType: NUMBER,
+			input: "-5",
+			token: Token{Value: "-5", Type: NUMBER},
 		},
 		{
-			input:     "-6.78",
-			str:       "-6.78",
-			TokenType: NUMBER,
+			input: "-6.78",
+			token: Token{Value: "-6.78", Type: NUMBER},
 		},
 		{
-			input:     "+9.10",
-			str:       "+9.10",
-			TokenType: NUMBER,
+			input: "+9.10",
+			token: Token{Value: "+9.10", Type: NUMBER},
 		},
 		{
-			input:     "1.2E3",
-			str:       "1.2E3",
-			TokenType: NUMBER,
+			input: "1.2E3",
+			token: Token{Value: "1.2E3", Type: NUMBER},
 		},
 		{
-			input:     "1.2E-3",
-			str:       "1.2E-3",
-			TokenType: NUMBER,
+			input: "1.2E-3",
+			token: Token{Value: "1.2E-3", Type: NUMBER},
 		},
 		{
-			input:     "-1.2E3",
-			str:       "-1.2E3",
-			TokenType: NUMBER,
+			input: "-1.2E3",
+			token: Token{Value: "-1.2E3", Type: NUMBER},
 		},
 		{
-			input:     "-1.2E-3",
-			str:       "-1.2E-3",
-			TokenType: NUMBER,
+			input: "-1.2E-3",
+			token: Token{Value: "-1.2E-3", Type: NUMBER},
 		},
 		// SINGLE_QUOTE_IDENT
 		{
-			input:     `'hoge'`,
-			str:       `'hoge'`,
-			TokenType: SINGLE_QUOTE_IDENT,
+			input: `'hoge'`,
+			token: Token{Value: `hoge`, Type: SINGLE_QUOTE_IDENT},
 		},
 		{
-			input:     `'ho''ge'`,
-			str:       `'ho'ge'`,
-			TokenType: SINGLE_QUOTE_IDENT,
+			input: `'ho''ge'`,
+			token: Token{Value: `ho'ge`, Type: SINGLE_QUOTE_IDENT},
 		},
 		// DOUBLE_QUOTE_IDENT
 		{
-			input:     `"hoge"`,
-			str:       `"hoge"`,
-			TokenType: DOUBLE_QUOTE_IDENT,
+			input: `"hoge"`,
+			token: Token{Value: `hoge`, Type: DOUBLE_QUOTE_IDENT},
 		},
 		{
-			input:     `"ho""ge"`,
-			str:       `"ho"ge"`,
-			TokenType: DOUBLE_QUOTE_IDENT,
+			input: `"ho""ge"`,
+			token: Token{Value: `ho"ge`, Type: DOUBLE_QUOTE_IDENT},
 		},
 		// BACKTICK_IDENT
 		{
-			input:     "`hoge`",
-			str:       "hoge",
-			TokenType: BACKTICK_IDENT,
+			input: "`hoge`",
+			token: Token{Value: "hoge", Type: BACKTICK_IDENT},
 		},
 		{
-			input:     "`ho``ge`",
-			str:       "ho`ge",
-			TokenType: BACKTICK_IDENT,
+			input: "`ho``ge`",
+			token: Token{Value: "ho`ge", Type: BACKTICK_IDENT},
 		},
 		// ESCAPED STRING BY BACKSLASH
 		{
-			input:     `'ho\'ge'`,
-			str:       `'ho'ge'`,
-			TokenType: SINGLE_QUOTE_IDENT,
+			input: `'ho\'ge'`,
+			token: Token{Value: `ho'ge`, Type: SINGLE_QUOTE_IDENT},
 		},
 	}
 
@@ -118,12 +102,11 @@ func TestRead(t *testing.T) {
 			t.Logf("%s", ctx.Err())
 			t.Fail()
 			return
-		case _t := <-ch:
-			if _t.Type != spec.TokenType {
-				t.Errorf("got %d expected %d spec:%v", _t, spec.TokenType, spec)
-			}
-			if _t.Value != spec.str {
-				t.Errorf("got %q expected %q spec:%v", _t.Value, spec.str, spec)
+		case tok := <-ch:
+			spec.token.Line = 1
+			spec.token.Col = 1
+			if !assert.Equal(t, spec.token, *tok, "tok matches") {
+				return
 			}
 		}
 	}

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -108,6 +108,7 @@ func TestRead(t *testing.T) {
 	}
 
 	for _, spec := range specs {
+		t.Logf("Lexing %s", spec.input)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -2,117 +2,128 @@ package schemalex
 
 import (
 	"testing"
+	"time"
+
+	"golang.org/x/net/context"
 )
 
 func TestRead(t *testing.T) {
 	type Spec struct {
-		input string
-		str   string
+		input     string
+		str       string
 		TokenType TokenType
 	}
 
 	specs := []Spec{
 		// number
 		{
-			input: "123",
-			str:   "123",
+			input:     "123",
+			str:       "123",
 			TokenType: NUMBER,
 		},
 		{
-			input: ".2",
-			str:   ".2",
+			input:     ".2",
+			str:       ".2",
 			TokenType: NUMBER,
 		},
 		{
-			input: "3.4",
-			str:   "3.4",
+			input:     "3.4",
+			str:       "3.4",
 			TokenType: NUMBER,
 		},
 		{
-			input: "-5",
-			str:   "-5",
+			input:     "-5",
+			str:       "-5",
 			TokenType: NUMBER,
 		},
 		{
-			input: "-6.78",
-			str:   "-6.78",
+			input:     "-6.78",
+			str:       "-6.78",
 			TokenType: NUMBER,
 		},
 		{
-			input: "+9.10",
-			str:   "+9.10",
+			input:     "+9.10",
+			str:       "+9.10",
 			TokenType: NUMBER,
 		},
 		{
-			input: "1.2E3",
-			str:   "1.2E3",
+			input:     "1.2E3",
+			str:       "1.2E3",
 			TokenType: NUMBER,
 		},
 		{
-			input: "1.2E-3",
-			str:   "1.2E-3",
+			input:     "1.2E-3",
+			str:       "1.2E-3",
 			TokenType: NUMBER,
 		},
 		{
-			input: "-1.2E3",
-			str:   "-1.2E3",
+			input:     "-1.2E3",
+			str:       "-1.2E3",
 			TokenType: NUMBER,
 		},
 		{
-			input: "-1.2E-3",
-			str:   "-1.2E-3",
+			input:     "-1.2E-3",
+			str:       "-1.2E-3",
 			TokenType: NUMBER,
 		},
 		// SINGLE_QUOTE_IDENT
 		{
-			input: `'hoge'`,
-			str:   `'hoge'`,
+			input:     `'hoge'`,
+			str:       `'hoge'`,
 			TokenType: SINGLE_QUOTE_IDENT,
 		},
 		{
-			input: `'ho''ge'`,
-			str:   `'ho'ge'`,
+			input:     `'ho''ge'`,
+			str:       `'ho'ge'`,
 			TokenType: SINGLE_QUOTE_IDENT,
 		},
 		// DOUBLE_QUOTE_IDENT
 		{
-			input: `"hoge"`,
-			str:   `"hoge"`,
+			input:     `"hoge"`,
+			str:       `"hoge"`,
 			TokenType: DOUBLE_QUOTE_IDENT,
 		},
 		{
-			input: `"ho""ge"`,
-			str:   `"ho"ge"`,
+			input:     `"ho""ge"`,
+			str:       `"ho"ge"`,
 			TokenType: DOUBLE_QUOTE_IDENT,
 		},
 		// BACKTICK_IDENT
 		{
-			input: "`hoge`",
-			str:   "hoge",
+			input:     "`hoge`",
+			str:       "hoge",
 			TokenType: BACKTICK_IDENT,
 		},
 		{
-			input: "`ho``ge`",
-			str:   "ho`ge",
+			input:     "`ho``ge`",
+			str:       "ho`ge",
 			TokenType: BACKTICK_IDENT,
 		},
 		// ESCAPED STRING BY BACKSLASH
 		{
-			input: `'ho\'ge'`,
-			str:   `'ho'ge'`,
+			input:     `'ho\'ge'`,
+			str:       `'ho'ge'`,
 			TokenType: SINGLE_QUOTE_IDENT,
 		},
 	}
 
 	for _, spec := range specs {
-		var l lexer
-		l.input = []byte(spec.input)
-		_t := l.read()
-		if _t.Type != spec.TokenType {
-			t.Errorf("got %d expected %d spec:%v", _t, spec.TokenType, spec)
-		}
-		if _t.Value != spec.str {
-			t.Errorf("got %q expected %q spec:%v", _t.Value, spec.str, spec)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		ch := Lex(ctx, []byte(spec.input))
+		select {
+		case <-ctx.Done():
+			t.Logf("%s", ctx.Err())
+			t.Fail()
+			return
+		case _t := <-ch:
+			if _t.Type != spec.TokenType {
+				t.Errorf("got %d expected %d spec:%v", _t, spec.TokenType, spec)
+			}
+			if _t.Value != spec.str {
+				t.Errorf("got %q expected %q spec:%v", _t.Value, spec.str, spec)
+			}
 		}
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -14,6 +14,11 @@ type Parser struct {
 	ErrorContext int
 }
 
+type ParseError struct {
+	Line int
+	Col  int
+}
+
 func New() *Parser {
 	return &Parser{}
 }
@@ -124,7 +129,7 @@ LOOP:
 			ctx.advance()
 			break LOOP
 		default:
-			return nil, p.parseErrorf(ctx, "should CREATE, COMMENT_IDENT or EOF")
+			return nil, p.parseErrorf(ctx, "expected CREATE, COMMENT_IDENT or EOF")
 		}
 	}
 
@@ -145,7 +150,7 @@ func (p *Parser) parseCreate(ctx *parseCtx) (Stmt, error) {
 	case TABLE:
 		return p.parseCreateTable(ctx)
 	default:
-		return nil, p.parseErrorf(ctx, "should DATABASE or TABLE")
+		return nil, p.parseErrorf(ctx, "expected DATABASE or TABLE")
 	}
 }
 
@@ -314,7 +319,6 @@ func (p *Parser) parseCreateTableFields(ctx *parseCtx, stmt *CreateTableStatemen
 						return nil, err
 					}
 				default:
-fmt.Printf("t.Type = %d\n", t.Type)
 					return nil, p.parseErrorf(ctx, "not supported")
 				}
 				return &indexStmt, nil

--- a/parser.go
+++ b/parser.go
@@ -76,7 +76,15 @@ func (p *Parser) ParseFile(fn string) (Statements, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, `failed to open file %s`, fn)
 	}
-	return p.Parse(src)
+
+	stmts, err := p.Parse(src)
+	if err != nil {
+		if pe, ok := err.(*ParseError); ok {
+			pe.file = fn
+		}
+		return nil, err
+	}
+	return stmts, nil
 }
 
 func (p *Parser) ParseString(src string) (Statements, error) {

--- a/parser.go
+++ b/parser.go
@@ -79,7 +79,7 @@ func (p *Parser) ParseFile(fn string) (Statements, error) {
 
 	stmts, err := p.Parse(src)
 	if err != nil {
-		if pe, ok := err.(*ParseError); ok {
+		if pe, ok := err.(*parseError); ok {
 			pe.file = fn
 		}
 		return nil, err
@@ -91,6 +91,10 @@ func (p *Parser) ParseString(src string) (Statements, error) {
 	return p.Parse([]byte(src))
 }
 
+// Parse parses the given set of SQL statements and creates a Statements
+// structure.
+// If it encounters errors while parsing, the returned error will be a
+// ParseError type.
 func (p *Parser) Parse(src []byte) (Statements, error) {
 	cctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -111,7 +115,7 @@ LOOP:
 					// this is ignorable.
 					continue
 				}
-				if pe, ok := err.(*ParseError); ok {
+				if pe, ok := err.(ParseError); ok {
 					return nil, pe
 				}
 				return nil, errors.Wrap(err, `failed to parse create`)

--- a/parser.go
+++ b/parser.go
@@ -293,6 +293,7 @@ func (p *Parser) parseCreateTableFields(ctx *parseCtx, stmt *CreateTableStatemen
 					copyStr := t.Value
 					indexStmt.Symbol.Valid = true
 					indexStmt.Symbol.Value = copyStr
+					ctx.advance()
 					ctx.skipWhiteSpaces()
 				}
 
@@ -313,6 +314,7 @@ func (p *Parser) parseCreateTableFields(ctx *parseCtx, stmt *CreateTableStatemen
 						return nil, err
 					}
 				default:
+fmt.Printf("t.Type = %d\n", t.Type)
 					return nil, p.parseErrorf(ctx, "not supported")
 				}
 				return &indexStmt, nil

--- a/parser.go
+++ b/parser.go
@@ -34,7 +34,9 @@ func newParseCtx(ctx context.Context) *parseCtx {
 
 var eofToken = Token{Type: EOF}
 
-// peek the next token. if already
+// peek the next token. this operation fills the peekTokens
+// buffer. `next()` is a combination of peek+advance.
+//
 // note: we do NOT check for peekCout > 2 for efficiency.
 // if you do that, you're f*cked.
 func (pctx *parseCtx) peek() *Token {

--- a/parser.go
+++ b/parser.go
@@ -19,7 +19,6 @@ func New() *Parser {
 type parseCtx struct {
 	context.Context
 	input      []byte
-	lexer      lexer // TODO delete
 	lexsrc     chan *Token
 	peekCount  int
 	peekTokens [3]*Token

--- a/parser.go
+++ b/parser.go
@@ -98,9 +98,8 @@ func (p *Parser) Parse(src []byte) (Statements, error) {
 	var stmts []Stmt
 LOOP:
 	for {
-		t := p.parseIgnoreWhiteSpace(ctx)
-	S1:
-		switch t.Type {
+		ctx.skipWhiteSpaces()
+		switch t := ctx.peek(); t.Type {
 		case CREATE:
 			stmt, err := p.parseCreate(ctx)
 			if err != nil {
@@ -112,14 +111,17 @@ LOOP:
 			}
 			stmts = append(stmts, stmt)
 		case COMMENT_IDENT:
+			ctx.advance()
 		case DROP, SET, USE:
 			// We don't do anything about these
+	S1:
 			for {
 				if p.eol(ctx) {
 					break S1
 				}
 			}
 		case EOF:
+			ctx.advance()
 			break LOOP
 		default:
 			return nil, p.parseErrorf(ctx, "should CREATE, COMMENT_IDENT or EOF")
@@ -130,8 +132,11 @@ LOOP:
 }
 
 func (p *Parser) parseCreate(ctx *parseCtx) (Stmt, error) {
-	t := p.parseIgnoreWhiteSpace(ctx)
-	switch t.Type {
+	if t := ctx.next(); t.Type != CREATE {
+		return nil, errors.New(`expected CREATE`)
+	}
+	ctx.skipWhiteSpaces()
+	switch t := ctx.peek(); t.Type {
 	case DATABASE:
 		if _, err := p.parseCreateDatabase(ctx); err != nil {
 			return nil, err
@@ -147,8 +152,12 @@ func (p *Parser) parseCreate(ctx *parseCtx) (Stmt, error) {
 // https://dev.mysql.com/doc/refman/5.5/en/create-database.html
 // TODO: charset, collation
 func (p *Parser) parseCreateDatabase(ctx *parseCtx) (*CreateDatabaseStatement, error) {
-	stmt := &CreateDatabaseStatement{}
-	t := p.parseIgnoreWhiteSpace(ctx)
+	if t := ctx.next(); t.Type != DATABASE {
+		return nil, errors.New(`expected DATABASE`)
+	}
+
+	var stmt CreateDatabaseStatement
+	var t *Token
 	setname := func() error {
 		switch t.Type {
 		case IDENT, BACKTICK_IDENT:
@@ -162,22 +171,24 @@ func (p *Parser) parseCreateDatabase(ctx *parseCtx) (*CreateDatabaseStatement, e
 		return p.parseErrorf(ctx, "should EOL")
 	}
 
-	switch t.Type {
+	ctx.skipWhiteSpaces()
+	switch t = ctx.next(); t.Type {
 	case IDENT, BACKTICK_IDENT:
 		if err := setname(); err != nil {
 			return nil, err
 		}
-		return stmt, nil
+		return &stmt, nil
 	case IF:
-		if _, err := p.parseIndents(ctx, NOT, EXISTS); err != nil {
+		if _, err := p.parseIdents(ctx, NOT, EXISTS); err != nil {
 			return nil, err
 		}
-		t = p.parseIgnoreWhiteSpace(ctx)
+		ctx.skipWhiteSpaces()
+		t = ctx.next()
 		stmt.IfNotExist = true
 		if err := setname(); err != nil {
 			return nil, err
 		}
-		return stmt, nil
+		return &stmt, nil
 	default:
 		return nil, p.parseErrorf(ctx, "should IDENT, BACKTICK_IDENT or IF")
 	}
@@ -185,33 +196,37 @@ func (p *Parser) parseCreateDatabase(ctx *parseCtx) (*CreateDatabaseStatement, e
 
 // http://dev.mysql.com/doc/refman/5.6/en/create-table.html
 func (p *Parser) parseCreateTable(ctx *parseCtx) (*CreateTableStatement, error) {
-	stmt := CreateTableStatement{}
-	t := p.parseIgnoreWhiteSpace(ctx)
-
-	if t.Type == TEMPORARY {
-		stmt.Temporary = true
-		// Advance to next token
-		t = p.parseIgnoreWhiteSpace(ctx)
+	if t := ctx.next(); t.Type != TABLE {
+		return nil, errors.New(`expected TABLE`)
 	}
 
-	switch t.Type {
+	var stmt CreateTableStatement
+
+	ctx.skipWhiteSpaces()
+	if t := ctx.peek(); t.Type == TEMPORARY {
+		ctx.advance()
+		ctx.skipWhiteSpaces()
+		stmt.Temporary = true
+	}
+
+	switch t := ctx.next(); t.Type {
 	case IDENT, BACKTICK_IDENT:
 		stmt.Name = t.Value
 	default:
 		return nil, p.parseErrorf(ctx, "expected IDENT or BACKTICK_IDENT")
 	}
 
-	t = p.parseIgnoreWhiteSpace(ctx)
-
-	if t.Type == IF {
-		if _, err := p.parseIndents(ctx, NOT, EXISTS); err != nil {
+	ctx.skipWhiteSpaces()
+	if t := ctx.peek(); t.Type == IF {
+		ctx.advance()
+		if _, err := p.parseIdents(ctx, NOT, EXISTS); err != nil {
 			return nil, p.parseErrorf(ctx, "should NOT EXISTS")
 		}
+		ctx.skipWhiteSpaces()
 		stmt.IfNotExist = true
-		t = p.parseIgnoreWhiteSpace(ctx)
 	}
 
-	if t.Type != LPAREN {
+	if t := ctx.next(); t.Type != LPAREN {
 		return nil, p.parseErrorf(ctx, "should (")
 	}
 
@@ -251,8 +266,8 @@ func (p *Parser) parseCreateTableFields(ctx *parseCtx, stmt *CreateTableStatemen
 	}
 
 	for {
-		t := p.parseIgnoreWhiteSpace(ctx)
-		switch t.Type {
+		ctx.skipWhiteSpaces()
+		switch t:= ctx.next(); t.Type {
 		case RPAREN:
 			appendStmt()
 			if err := p.parseCreateTableOptions(ctx, stmt); err != nil {
@@ -270,17 +285,18 @@ func (p *Parser) parseCreateTableFields(ctx *parseCtx, stmt *CreateTableStatemen
 			appendStmt()
 		case CONSTRAINT:
 			err := setStmt(func() (interface{}, error) {
-				indexStmt := CreateTableIndexStatement{}
-				t := p.parseIgnoreWhiteSpace(ctx)
-				if t.Type == IDENT || t.Type == BACKTICK_IDENT {
+				var indexStmt CreateTableIndexStatement
+				ctx.skipWhiteSpaces()
+				switch t := ctx.peek(); t.Type {
+				case IDENT, BACKTICK_IDENT:
 					// TODO: should smart
 					copyStr := t.Value
 					indexStmt.Symbol.Valid = true
 					indexStmt.Symbol.Value = copyStr
-					t = p.parseIgnoreWhiteSpace(ctx)
+					ctx.skipWhiteSpaces()
 				}
 
-				switch t.Type {
+				switch t := ctx.next(); t.Type {
 				case PRIMARY:
 					indexStmt.Kind = IndexKindPrimaryKey
 					if err := p.parseColumnIndexPrimaryKey(ctx, &indexStmt); err != nil {
@@ -385,10 +401,10 @@ func (p *Parser) parseCreateTableFields(ctx *parseCtx, stmt *CreateTableStatemen
 			err := setStmt(func() (interface{}, error) {
 				colStmt := CreateTableColumnStatement{}
 				colStmt.Name = t.Value
-				t := p.parseIgnoreWhiteSpace(ctx)
 
 				var err error
-				switch t.Type {
+				ctx.skipWhiteSpaces()
+				switch t := ctx.next(); t.Type {
 				case BIT:
 					colStmt.Type = ColumnTypeBit
 					err = p.parseColumnOption(ctx, &colStmt, ColumnOptionSize)
@@ -501,10 +517,12 @@ func (p *Parser) parseCreateTableFields(ctx *parseCtx, stmt *CreateTableStatemen
 func (p *Parser) parseCreateTableOptions(ctx *parseCtx, stmt *CreateTableStatement) error {
 
 	setOption := func(key string, types []TokenType) error {
-		t := p.parseIgnoreWhiteSpace(ctx)
-		if t.Type == EQUAL {
-			t = p.parseIgnoreWhiteSpace(ctx)
+		ctx.skipWhiteSpaces()
+		if t := ctx.peek(); t.Type == EQUAL {
+			ctx.advance()
+			ctx.skipWhiteSpaces()
 		}
+		t := ctx.next()
 		for _, typ := range types {
 			if typ == t.Type {
 				stmt.Options = append(stmt.Options, &CreateTableOptionStatement{key, t.Value})
@@ -515,8 +533,8 @@ func (p *Parser) parseCreateTableOptions(ctx *parseCtx, stmt *CreateTableStateme
 	}
 
 	for {
-		t := p.parseIgnoreWhiteSpace(ctx)
-		switch t.Type {
+		ctx.skipWhiteSpaces()
+		switch t := ctx.next(); t.Type {
 		case ENGINE:
 			if err := setOption("ENGINE", []TokenType{IDENT, BACKTICK_IDENT}); err != nil {
 				return err
@@ -530,12 +548,12 @@ func (p *Parser) parseCreateTableOptions(ctx *parseCtx, stmt *CreateTableStateme
 				return err
 			}
 		case DEFAULT:
-			t := p.parseIgnoreWhiteSpace(ctx)
-			switch t.Type {
+			ctx.skipWhiteSpaces()
+			switch t := ctx.next(); t.Type {
 			case CHARACTER:
-				t := p.parseIgnoreWhiteSpace(ctx)
-				if t.Type != SET {
-					return p.parseErrorf(ctx, "should SET")
+				ctx.skipWhiteSpaces()
+				if t := ctx.next(); t.Type != SET {
+					return p.parseErrorf(ctx, "expected SET")
 				}
 				if err := setOption("DEFAULT CHARACTER SET", []TokenType{IDENT, BACKTICK_IDENT}); err != nil {
 					return err
@@ -545,12 +563,12 @@ func (p *Parser) parseCreateTableOptions(ctx *parseCtx, stmt *CreateTableStateme
 					return err
 				}
 			default:
-				return p.parseErrorf(ctx, "should CHARACTER or COLLATE")
+				return p.parseErrorf(ctx, "expected CHARACTER or COLLATE")
 			}
 		case CHARACTER:
-			t := p.parseIgnoreWhiteSpace(ctx)
-			if t.Type != SET {
-				return p.parseErrorf(ctx, "should SET")
+			ctx.skipWhiteSpaces()
+			if t := ctx.next(); t.Type != SET {
+				return p.parseErrorf(ctx, "expected SET")
 			}
 			if err := setOption("DEFAULT CHARACTER SET", []TokenType{IDENT, BACKTICK_IDENT}); err != nil {
 				return err
@@ -572,8 +590,8 @@ func (p *Parser) parseCreateTableOptions(ctx *parseCtx, stmt *CreateTableStateme
 				return err
 			}
 		case DATA:
-			t := p.parseIgnoreWhiteSpace(ctx)
-			if t.Type != DIRECTORY {
+			ctx.skipWhiteSpaces()
+			if t := ctx.next(); t.Type != DIRECTORY {
 				return p.parseErrorf(ctx, "should DIRECTORY")
 			}
 			if err := setOption("DATA DIRECTORY", []TokenType{SINGLE_QUOTE_IDENT, DOUBLE_QUOTE_IDENT}); err != nil {
@@ -584,8 +602,8 @@ func (p *Parser) parseCreateTableOptions(ctx *parseCtx, stmt *CreateTableStateme
 				return err
 			}
 		case INDEX:
-			t := p.parseIgnoreWhiteSpace(ctx)
-			if t.Type != DIRECTORY {
+			ctx.skipWhiteSpaces()
+			if t := ctx.next(); t.Type != DIRECTORY {
 				return p.parseErrorf(ctx, "should DIRECTORY")
 			}
 			if err := setOption("INDEX DIRECTORY", []TokenType{SINGLE_QUOTE_IDENT, DOUBLE_QUOTE_IDENT}); err != nil {
@@ -638,7 +656,7 @@ func (p *Parser) parseCreateTableOptions(ctx *parseCtx, stmt *CreateTableStateme
 		case EOF:
 			return nil
 		case SEMICOLON:
-			p.reset(ctx)
+			ctx.rewind()
 			return nil
 		default:
 			return p.parseErrorf(ctx, "unexpected table options")
@@ -661,23 +679,26 @@ func (p *Parser) parseColumnOption(ctx *parseCtx, col *CreateTableColumnStatemen
 		return true
 	}
 	for {
-		t := p.parseIgnoreWhiteSpace(ctx)
-		switch t.Type {
+		ctx.skipWhiteSpaces()
+		switch t := ctx.next(); t.Type {
 		case LPAREN:
 			if check(ColumnOptionSize) {
-				t := p.parseIgnoreWhiteSpace(ctx)
-				tlen := t.Value
+				ctx.skipWhiteSpaces()
+				t := ctx.next();
 				if t.Type != NUMBER {
-					return p.parseErrorf(ctx, "should NUMBER")
+					return p.parseErrorf(ctx, "expected NUMBER (column size)")
 				}
-				t = p.parseIgnoreWhiteSpace(ctx)
+				tlen := t.Value
+
+				ctx.skipWhiteSpaces()
+				t = ctx.next()
 				if t.Type != RPAREN {
-					return p.parseErrorf(ctx, "should )")
+					return p.parseErrorf(ctx, "expected RPAREN (column size)")
 				}
 				col.Length.Valid = true
 				col.Length.Length = tlen
 			} else if check(ColumnOptionDecimalSize) {
-				strs, err := p.parseIndents(ctx, NUMBER, COMMA, NUMBER, RPAREN)
+				strs, err := p.parseIdents(ctx, NUMBER, COMMA, NUMBER, RPAREN)
 				if err != nil {
 					return err
 				}
@@ -686,31 +707,38 @@ func (p *Parser) parseColumnOption(ctx *parseCtx, col *CreateTableColumnStatemen
 				col.Length.Decimals.Valid = true
 				col.Length.Decimals.Value = strs[2]
 			} else if check(ColumnOptionDecimalOptionalSize) {
-				t := p.parseIgnoreWhiteSpace(ctx)
+				ctx.skipWhiteSpaces()
+				t := ctx.next()
 				if t.Type != NUMBER {
-					return p.parseErrorf(ctx, "should NUMBER")
+					return p.parseErrorf(ctx, "expected NUMBER (decimal size `M`)")
 				}
-				t = p.parseIgnoreWhiteSpace(ctx)
 				tlen := t.Value
+
+				ctx.skipWhiteSpaces()
+				t = ctx.next()
 				if t.Type == RPAREN {
 					col.Length.Valid = true
 					col.Length.Length = tlen
 					continue
 				} else if t.Type != COMMA {
-					return p.parseErrorf(ctx, "should ,")
+					return p.parseErrorf(ctx, "expected COMMA (decimal size)")
 				}
-				t = p.parseIgnoreWhiteSpace(ctx)
+
+				ctx.skipWhiteSpaces()
+				t = ctx.next()
 				if t.Type != NUMBER {
-					return p.parseErrorf(ctx, "should NUMBER")
+					return p.parseErrorf(ctx, "expected NUMBER (decimal size `D`)")
 				}
-				t = p.parseIgnoreWhiteSpace(ctx)
-				if t.Type != RPAREN {
-					return p.parseErrorf(ctx, "should )")
+				tscale := t.Value
+
+				ctx.skipWhiteSpaces()
+				if t := ctx.next(); t.Type != RPAREN {
+					return p.parseErrorf(ctx, "expected RPARENT (decimal size)")
 				}
 				col.Length.Valid = true
 				col.Length.Length = tlen
 				col.Length.Decimals.Valid = true
-				col.Length.Decimals.Value = t.Value
+				col.Length.Decimals.Value = tscale
 			} else {
 				return p.parseErrorf(ctx, "cant apply ColumnOptionSize, ColumnOptionDecimalSize, ColumnOptionDecimalOptionalSize")
 			}
@@ -733,10 +761,11 @@ func (p *Parser) parseColumnOption(ctx *parseCtx, col *CreateTableColumnStatemen
 			if !check(ColumnOptionNull) {
 				return p.parseErrorf(ctx, "cant apply NOT NULL")
 			}
-			t := p.parseIgnoreWhiteSpace(ctx)
-			if t.Type == NULL {
+			ctx.skipWhiteSpaces()
+			switch t := ctx.next(); t.Type {
+			case NULL:
 				col.Null = ColumnOptionNullStateNotNull
-			} else {
+			default:
 				return p.parseErrorf(ctx, "should NULL")
 			}
 		case NULL:
@@ -748,9 +777,8 @@ func (p *Parser) parseColumnOption(ctx *parseCtx, col *CreateTableColumnStatemen
 			if !check(ColumnOptionDefault) {
 				return p.parseErrorf(ctx, "cant apply DEFAULT")
 			}
-			// TODO type
-			t := p.parseIgnoreWhiteSpace(ctx)
-			switch t.Type {
+			ctx.skipWhiteSpaces()
+			switch t := ctx.next(); t.Type {
 			case IDENT, SINGLE_QUOTE_IDENT, DOUBLE_QUOTE_IDENT, NUMBER, CURRENT_TIMESTAMP, NULL:
 				col.Default.Valid = true
 				col.Default.Value = t.Value
@@ -766,11 +794,11 @@ func (p *Parser) parseColumnOption(ctx *parseCtx, col *CreateTableColumnStatemen
 			if !check(ColumnOptionKey) {
 				return p.parseErrorf(ctx, "cant apply UNIQUE KEY")
 			}
-			t := p.parseIgnoreWhiteSpace(ctx)
-			if t.Type != KEY {
-				p.reset(ctx)
+			ctx.skipWhiteSpaces()
+			if t := ctx.next(); t.Type == KEY {
+				ctx.advance()
+				col.Unique = true
 			}
-			col.Unique = true
 		case KEY:
 			if !check(ColumnOptionKey) {
 				return p.parseErrorf(ctx, "cant apply KEY")
@@ -780,26 +808,28 @@ func (p *Parser) parseColumnOption(ctx *parseCtx, col *CreateTableColumnStatemen
 			if !check(ColumnOptionKey) {
 				return p.parseErrorf(ctx, "cant apply PRIMARY KEY")
 			}
-			t := p.parseIgnoreWhiteSpace(ctx)
-			if t.Type != KEY {
-				p.reset(ctx)
+			ctx.skipWhiteSpaces()
+			if t := ctx.peek(); t.Type == KEY {
+				ctx.advance()
+				col.Primary = true
 			}
-			col.Primary = true
 		case COMMENT:
 			if !check(ColumnOptionComment) {
 				return p.parseErrorf(ctx, "cant apply COMMENT")
 			}
-			t := p.parseIgnoreWhiteSpace(ctx)
-			if t.Type != SINGLE_QUOTE_IDENT {
+			ctx.skipWhiteSpaces()
+			switch t := ctx.next(); t.Type {
+			case SINGLE_QUOTE_IDENT:
+				col.Comment.Valid = true
+				col.Comment.Value = t.Value
+			default:
 				return p.parseErrorf(ctx, "should SINGLE_QUOTE_IDENT")
 			}
-			col.Comment.Valid = true
-			col.Comment.Value = t.Value
 		case COMMA:
-			p.reset(ctx)
+			ctx.rewind()
 			return nil
 		case RPAREN:
-			p.reset(ctx)
+			ctx.rewind()
 			return nil
 		default:
 			return p.parseErrorf(ctx, "unexpected column options")
@@ -808,8 +838,8 @@ func (p *Parser) parseColumnOption(ctx *parseCtx, col *CreateTableColumnStatemen
 }
 
 func (p *Parser) parseColumnIndexPrimaryKey(ctx *parseCtx, stmt *CreateTableIndexStatement) error {
-	t := p.parseIgnoreWhiteSpace(ctx)
-	if t.Type != KEY {
+	ctx.skipWhiteSpaces()
+	if t := ctx.next(); t.Type != KEY {
 		return p.parseErrorf(ctx, "should KEY")
 	}
 	if err := p.parseColumnIndexType(ctx, stmt); err != nil {
@@ -826,9 +856,10 @@ func (p *Parser) parseColumnIndexPrimaryKey(ctx *parseCtx, stmt *CreateTableInde
 }
 
 func (p *Parser) parseColumnIndexUniqueKey(ctx *parseCtx, stmt *CreateTableIndexStatement) error {
-	t := p.parseIgnoreWhiteSpace(ctx)
-	if !(t.Type == KEY || t.Type == INDEX) {
-		p.reset(ctx)
+	ctx.skipWhiteSpaces()
+	switch t := ctx.peek(); t.Type {
+	case KEY, INDEX:
+		ctx.advance()
 	}
 
 	if err := p.parseColumnIndexName(ctx, stmt); err != nil {
@@ -879,8 +910,8 @@ func (p *Parser) parseColumnIndexFullTextKey(ctx *parseCtx, stmt *CreateTableInd
 }
 
 func (p *Parser) parseColumnIndexForeignKey(ctx *parseCtx, stmt *CreateTableIndexStatement) error {
-	t := p.parseIgnoreWhiteSpace(ctx)
-	if t.Type != KEY {
+	ctx.skipWhiteSpaces()
+	if t := ctx.next(); t.Type != KEY {
 		return p.parseErrorf(ctx, "should KEY")
 	}
 	if err := p.parseColumnIndexName(ctx, stmt); err != nil {
@@ -893,9 +924,8 @@ func (p *Parser) parseColumnIndexForeignKey(ctx *parseCtx, stmt *CreateTableInde
 	}
 	stmt.ColNames = append(stmt.ColNames, cols...)
 
-	t = p.parseIgnoreWhiteSpace(ctx)
-	p.reset(ctx)
-	if t.Type == REFERENCES {
+	ctx.skipWhiteSpaces()
+	if t := ctx.peek(); t.Type == REFERENCES {
 		if err := p.parseColumnReference(ctx, stmt); err != nil {
 			return err
 		}
@@ -904,19 +934,46 @@ func (p *Parser) parseColumnIndexForeignKey(ctx *parseCtx, stmt *CreateTableInde
 	return nil
 }
 
+func (p *Parser) parseReferenceOption(ctx *parseCtx, opt *ReferenceOption) error {
+	ctx.skipWhiteSpaces()
+	switch t := ctx.next(); t.Type {
+	case RESTRICT:
+		*opt = ReferenceOptionRestrict
+	case CASCADE:
+		*opt = ReferenceOptionCascade
+	case SET:
+		ctx.skipWhiteSpaces()
+		if t := ctx.next(); t.Type != NULL {
+			return p.parseErrorf(ctx, "expected NULL")
+		}
+		*opt = ReferenceOptionSetNull
+	case NO:
+		ctx.skipWhiteSpaces()
+		if t := ctx.next(); t.Type != ACTION {
+			return p.parseErrorf(ctx, "expected ACTION")
+		}
+		*opt = ReferenceOptionNoAction
+	default:
+		return p.parseErrorf(ctx, "expected RESTRICT, CASCADE, SET or NO")
+	}
+	return nil
+}
+
 func (p *Parser) parseColumnReference(ctx *parseCtx, stmt *CreateTableIndexStatement) error {
 	var r Reference
 
-	t := p.parseIgnoreWhiteSpace(ctx)
-	if t.Type != REFERENCES {
-		return p.parseErrorf(ctx, "should REFERENCES")
+	ctx.skipWhiteSpaces()
+	if t := ctx.next(); t.Type != REFERENCES {
+		return p.parseErrorf(ctx, "expected REFERENCES")
 	}
 
-	t = p.parseIgnoreWhiteSpace(ctx)
-	if !(t.Type == IDENT || t.Type == BACKTICK_IDENT) {
+	ctx.skipWhiteSpaces()
+	switch t := ctx.next(); t.Type {
+	case BACKTICK_IDENT, IDENT:
+		r.TableName = t.Value
+	default:
 		return p.parseErrorf(ctx, "should IDENT or BACKTICK_IDENT")
 	}
-	r.TableName = t.Value
 
 	cols, err := p.parseColumnIndexColName(ctx, stmt)
 	if err != nil {
@@ -924,10 +981,11 @@ func (p *Parser) parseColumnReference(ctx *parseCtx, stmt *CreateTableIndexState
 	}
 	r.ColNames = append(r.ColNames, cols...)
 
-	t = p.parseIgnoreWhiteSpace(ctx)
-	if t.Type == MATCH {
-		t = p.parseIgnoreWhiteSpace(ctx)
-		switch t.Type {
+	ctx.skipWhiteSpaces()
+	if t := ctx.peek(); t.Type == MATCH {
+		ctx.advance()
+		ctx.skipWhiteSpaces()
+		switch t = ctx.next(); t.Type {
 		case FULL:
 			r.Match = ReferenceMatchFull
 		case PARTIAL:
@@ -937,110 +995,74 @@ func (p *Parser) parseColumnReference(ctx *parseCtx, stmt *CreateTableIndexState
 		default:
 			return p.parseErrorf(ctx, "should FULL, PARTIAL or SIMPLE")
 		}
-		t = p.parseIgnoreWhiteSpace(ctx)
+		ctx.skipWhiteSpaces()
 	}
 
-	if t.Type != ON {
-		p.reset(ctx)
-		stmt.Reference = &r
-		return nil
-	}
+	// ON DELETE can be followed by ON UPDATE, but
+	// ON UPDATE cannot be followed by ON DELETE
+OUTER:
+	for i := 0; i < 2; i++ {
+		ctx.skipWhiteSpaces()
+		if t := ctx.peek(); t.Type != ON {
+			break OUTER
+		}
+		ctx.advance()
+		ctx.skipWhiteSpaces()
 
-	parseRefenceOption := func() (ReferenceOption, error) {
-		t = p.parseIgnoreWhiteSpace(ctx)
-		switch t.Type {
-		case RESTRICT:
-			return ReferenceOptionRestrict, nil
-		case CASCADE:
-			return ReferenceOptionCascade, nil
-		case SET:
-			t := p.parseIgnoreWhiteSpace(ctx)
-			if t.Type != NULL {
-				return 0, p.parseErrorf(ctx, "should NULL")
+		switch t := ctx.next(); t.Type {
+		case DELETE:
+			if err := p.parseReferenceOption(ctx, &r.OnDelete); err != nil {
+				return errors.Wrap(err, `failed to parse ON DELETE`)
 			}
-			return ReferenceOptionSetNull, nil
-		case NO:
-			t := p.parseIgnoreWhiteSpace(ctx)
-			if t.Type != ACTION {
-				return 0, p.parseErrorf(ctx, "should ACTION")
+		case UPDATE:
+			if err := p.parseReferenceOption(ctx, &r.OnUpdate); err != nil {
+				return errors.Wrap(err, `failed to parse ON UPDATE`)
 			}
-			return ReferenceOptionNoAction, nil
+			break OUTER
 		default:
-			return 0, p.parseErrorf(ctx, "should RESTRICT, CASCADE, SET or NO")
+			return p.parseErrorf(ctx, "expected DELETE or UPDATE")
 		}
-	}
-
-	t = p.parseIgnoreWhiteSpace(ctx)
-	switch t.Type {
-	case DELETE:
-		option, err := parseRefenceOption()
-		if err != nil {
-			return err
-		}
-		r.OnDelete = option
-	case UPDATE:
-		option, err := parseRefenceOption()
-		if err != nil {
-			return err
-		}
-		r.OnUpdate = option
-		stmt.Reference = &r
-		return nil
-	default:
-		return p.parseErrorf(ctx, "should DELETE or UPDATE")
-	}
-
-	t = p.parseIgnoreWhiteSpace(ctx)
-	if t.Type != ON {
-		p.reset(ctx)
-		stmt.Reference = &r
-		return nil
-	}
-
-	t = p.parseIgnoreWhiteSpace(ctx)
-	switch t.Type {
-	case UPDATE:
-		option, err := parseRefenceOption()
-		if err != nil {
-			return err
-		}
-		r.OnUpdate = option
-	default:
-		return p.parseErrorf(ctx, "should UPDATE")
 	}
 
 	stmt.Reference = &r
-
 	return nil
 }
 
 func (p *Parser) parseColumnIndexName(ctx *parseCtx, stmt *CreateTableIndexStatement) error {
-	t := p.parseIgnoreWhiteSpace(ctx)
-	if t.Type == BACKTICK_IDENT || t.Type == IDENT {
+	ctx.skipWhiteSpaces()
+	switch t := ctx.peek(); t.Type {
+	case BACKTICK_IDENT, IDENT:
+		ctx.advance()
 		stmt.Name.Valid = true
 		stmt.Name.Value = t.Value
-	} else {
-		p.reset(ctx)
+	}
+	return nil
+}
+
+func (p *Parser) parseColumnIndexTypeUsing(ctx *parseCtx, stmt *CreateTableIndexStatement) error {
+	if t := ctx.next(); t.Type != USING {
+		return errors.New(`expected USING`)
+	}
+
+	ctx.skipWhiteSpaces()
+	switch t := ctx.next(); t.Type {
+	case BTREE:
+		stmt.Type = IndexTypeBtree
+	case HASH:
+		stmt.Type = IndexTypeHash
+	default:
+		return p.parseErrorf(ctx, "should BTREE or HASH")
 	}
 	return nil
 }
 
 func (p *Parser) parseColumnIndexType(ctx *parseCtx, stmt *CreateTableIndexStatement) error {
-	t := p.parseIgnoreWhiteSpace(ctx)
-	if t.Type == USING {
-		t = p.parseIgnoreWhiteSpace(ctx)
-		switch t.Type {
-		case BTREE:
-			stmt.Type = IndexTypeBtree
-		case HASH:
-			stmt.Type = IndexTypeHash
-		default:
-			return p.parseErrorf(ctx, "should BTREE or HASH")
-		}
-	} else {
-		p.reset(ctx)
-		stmt.Type = IndexTypeNone
+	ctx.skipWhiteSpaces()
+	if t := ctx.peek(); t.Type == USING {
+		return p.parseColumnIndexTypeUsing(ctx, stmt)
 	}
+
+	stmt.Type = IndexTypeNone
 	return nil
 }
 
@@ -1048,19 +1070,21 @@ func (p *Parser) parseColumnIndexType(ctx *parseCtx, stmt *CreateTableIndexState
 func (p *Parser) parseColumnIndexColName(ctx *parseCtx, stmt *CreateTableIndexStatement) ([]string, error) {
 	var strs []string
 
-	t := p.parseIgnoreWhiteSpace(ctx)
-	if t.Type != LPAREN {
+	ctx.skipWhiteSpaces()
+	if t := ctx.next(); t.Type != LPAREN {
 		return nil, p.parseErrorf(ctx, "should (")
 	}
 
 	for {
-		t := p.parseIgnoreWhiteSpace(ctx)
+		ctx.skipWhiteSpaces()
+		t := ctx.next()
 		if !(t.Type == IDENT || t.Type == BACKTICK_IDENT) {
 			return nil, p.parseErrorf(ctx, "should IDENT or BACKTICK_IDENT")
 		}
 		strs = append(strs, t.Value)
-		t = p.parseIgnoreWhiteSpace(ctx)
-		switch t.Type {
+
+		ctx.skipWhiteSpaces()
+		switch t = ctx.next(); t.Type {
 		case COMMA:
 			// search next
 			continue
@@ -1072,26 +1096,26 @@ func (p *Parser) parseColumnIndexColName(ctx *parseCtx, stmt *CreateTableIndexSt
 	}
 }
 
-// util
-func (p *Parser) parseIgnoreWhiteSpace(ctx *parseCtx) *Token {
+// Skips over whitespaces. Once this method returns, you can be
+// certain that next call to ctx.next()/peek() will result in a
+// non-space token
+func (ctx *parseCtx) skipWhiteSpaces() {
 	for {
-		t := ctx.next()
-		//log.Println("parseIgnoreWhiteSpace:", int(t), p.lexer.str())
-
-		if t.Type == SPACE || t.Type == COMMENT_IDENT {
+		switch t := ctx.peek(); t.Type {
+		case SPACE, COMMENT_IDENT:
+			ctx.advance()
 			continue
+		default:
+			return
 		}
-
-		return t
 	}
-
-	return &Token{Type: ILLEGAL}
 }
 
-func (p *Parser) parseIndents(ctx *parseCtx, idents ...TokenType) ([]string, error) {
+func (p *Parser) parseIdents(ctx *parseCtx, idents ...TokenType) ([]string, error) {
 	strs := []string{}
 	for _, ident := range idents {
-		t := p.parseIgnoreWhiteSpace(ctx)
+		ctx.skipWhiteSpaces()
+		t := ctx.next()
 		if t.Type != ident {
 			return nil, p.parseErrorf(ctx, "should %v", idents)
 		}
@@ -1101,18 +1125,14 @@ func (p *Parser) parseIndents(ctx *parseCtx, idents ...TokenType) ([]string, err
 }
 
 func (p *Parser) eol(ctx *parseCtx) bool {
-	t := p.parseIgnoreWhiteSpace(ctx)
-	switch t.Type {
+	ctx.skipWhiteSpaces()
+	switch t := ctx.peek(); t.Type {
 	case EOF, SEMICOLON:
+		ctx.advance()
 		return true
 	default:
 		return false
 	}
-}
-
-// temporary
-func (p *Parser) reset(ctx *parseCtx) {
-	ctx.rewind()
 }
 
 func (p *Parser) parseErrorf(ctx *parseCtx, format string, a ...interface{}) error {

--- a/parser_test.go
+++ b/parser_test.go
@@ -240,8 +240,8 @@ func TestParseFileError(t *testing.T) {
 		return
 	}
 
-	pe, ok := err.(*ParseError)
-	if !assert.True(t, ok, "err is a *ParseError") {
+	pe, ok := err.(ParseError)
+	if !assert.True(t, ok, "err is a ParseError") {
 		return
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -145,6 +145,10 @@ id bigint unsigned not null auto_increment
 			Input: "create table hoge (`foo` DECIMAL(32,30))",
 			Expect: "CREATE TABLE `hoge` (\n`foo` DECIMAL (32,30)\n)",
 		},
+		{
+			Input: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, CONSTRAINT `symbol` UNIQUE KEY `uniq_id` USING BTREE (`id`) )",
+			Expect: "CREATE TABLE `fuga` (\n`id` INTEGER NOT NULL AUTO_INCREMENT,\nCONSTRAINT `symbol` UNIQUE INDEX `uniq_id` USING BTREE (`id`)\n)",
+		},
 	}
 
 	p := New()

--- a/parser_test.go
+++ b/parser_test.go
@@ -202,7 +202,7 @@ func TestParseError1(t *testing.T) {
 		return
 	}
 
-	expected := "parse error: expected RPAREN at line 2 column 16 (at EOF)\n\"CREATE TABLE bar\" <---- AROUND HERE"
+	expected := "parse error: expected RPAREN at line 2 column 16 (at EOF)\n    \"CREATE TABLE bar\" <---- AROUND HERE"
 	if !assert.Equal(t, expected, err.Error(), "error matches") {
 		return
 	}
@@ -216,7 +216,7 @@ func TestParseError2(t *testing.T) {
 		return
 	}
 
-	expected := "parse error: unexpected column options at line 2 column 37\n\"CREATE TABLE bar (id int PRIMARY KEY \" <---- AROUND HERE"
+	expected := "parse error: unexpected column options at line 2 column 37\n    \"CREATE TABLE bar (id int PRIMARY KEY \" <---- AROUND HERE"
 	if !assert.Equal(t, expected, err.Error(), "error matches") {
 		return
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -141,6 +141,10 @@ id bigint unsigned not null auto_increment
 			Error:  true,
 			Expect: "",
 		},
+		{
+			Input: "create table hoge (`foo` DECIMAL(32,30))",
+			Expect: "CREATE TABLE `hoge` (\n`foo` DECIMAL (32,30)\n)",
+		},
 	}
 
 	p := New()

--- a/parser_test.go
+++ b/parser_test.go
@@ -193,3 +193,31 @@ func TestFile(t *testing.T) {
 		t.Log(stmt)
 	}
 }
+
+func TestParseError1(t *testing.T) {
+	const src = "CREATE TABLE foo (id int PRIMARY KEY);\nCREATE TABLE bar"
+	p := New()
+	_, err := p.ParseString(src)
+	if !assert.Error(t, err, "parse should fail") {
+		return
+	}
+
+	expected := "parse error: expected RPAREN at line 2 column 16 (at EOF)\n\"CREATE TABLE bar\" <---- AROUND HERE"
+	if !assert.Equal(t, expected, err.Error(), "error matches") {
+		return
+	}
+}
+
+func TestParseError2(t *testing.T) {
+	const src = "CREATE TABLE foo (id int PRIMARY KEY);\nCREATE TABLE bar (id int PRIMARY KEY baz TEXT)"
+	p := New()
+	_, err := p.ParseString(src)
+	if !assert.Error(t, err, "parse should fail") {
+		return
+	}
+
+	expected := "parse error: unexpected column options at line 2 column 37\n\"CREATE TABLE bar (id int PRIMARY KEY \" <---- AROUND HERE"
+	if !assert.Equal(t, expected, err.Error(), "error matches") {
+		return
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -145,24 +145,23 @@ id bigint unsigned not null auto_increment
 
 	p := New()
 	for _, spec := range specs {
+		t.Logf("Parsing '%s'", spec.Input)
 		stmts, err := p.ParseString(spec.Input)
 		if spec.Error {
 			if !assert.Error(t, err, "should be an error") {
-				t.Logf("input: %s", spec.Input)
 				continue
 			}
 		} else {
 			if err != nil {
 				t.Errorf(err.Error())
-				t.Logf("input:%s", spec.Input)
-				continue
+				return
 			}
 
 			var buf bytes.Buffer
 			stmts.WriteTo(&buf)
 
-			if e, g := spec.Expect, buf.String(); e != g {
-				t.Errorf("should:%q\n got:%q", e, g)
+			if !assert.Equal(t, spec.Expect, buf.String(), "should match") {
+				return
 			}
 		}
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -142,11 +143,11 @@ id bigint unsigned not null auto_increment
 			Expect: "",
 		},
 		{
-			Input: "create table hoge (`foo` DECIMAL(32,30))",
+			Input:  "create table hoge (`foo` DECIMAL(32,30))",
 			Expect: "CREATE TABLE `hoge` (\n`foo` DECIMAL (32,30)\n)",
 		},
 		{
-			Input: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, CONSTRAINT `symbol` UNIQUE KEY `uniq_id` USING BTREE (`id`) )",
+			Input:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, CONSTRAINT `symbol` UNIQUE KEY `uniq_id` USING BTREE (`id`) )",
 			Expect: "CREATE TABLE `fuga` (\n`id` INTEGER NOT NULL AUTO_INCREMENT,\nCONSTRAINT `symbol` UNIQUE INDEX `uniq_id` USING BTREE (`id`)\n)",
 		},
 	}
@@ -218,6 +219,38 @@ func TestParseError2(t *testing.T) {
 
 	expected := "parse error: unexpected column options at line 2 column 37\n    \"CREATE TABLE bar (id int PRIMARY KEY \" <---- AROUND HERE"
 	if !assert.Equal(t, expected, err.Error(), "error matches") {
+		return
+	}
+}
+
+func TestParseFileError(t *testing.T) {
+	f, err := ioutil.TempFile("", "schemalex-file")
+	if !assert.NoError(t, err, "creating tempfile should succeed") {
+		return
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	f.Write([]byte("CREATE TABLE foo (id int PRIMARY KEY);\nCREATE TABLE bar (id int PRIMARY KEY baz TEXT)"))
+	f.Sync()
+
+	p := New()
+	_, err = p.ParseFile(f.Name())
+	if !assert.Error(t, err, "schemalex.ParseFile should fail") {
+		return
+	}
+
+	pe, ok := err.(*ParseError)
+	if !assert.True(t, ok, "err is a *ParseError") {
+		return
+	}
+
+	if !assert.Equal(t, f.Name(), pe.File(), "pe.File() should be the filename") {
+		return
+	}
+
+	expected := "parse error: unexpected column options in file " + f.Name() + " at line 2 column 37\n    \"CREATE TABLE bar (id int PRIMARY KEY \" <---- AROUND HERE"
+	if !assert.Equal(t, expected, pe.Error(), "pe.Error() matches expected") {
 		return
 	}
 }

--- a/statement.go
+++ b/statement.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 )
 
 type ider interface {
@@ -191,7 +192,7 @@ func (c CreateTableColumnStatement) WriteTo(dst io.Writer) (int64, error) {
 
 	if c.Default.Valid {
 		buf.WriteString(" DEFAULT ")
-		buf.WriteString(c.Default.Value)
+		buf.WriteString(strconv.Quote(c.Default.Value))
 	}
 
 	if c.AutoIncrement {

--- a/statement.go
+++ b/statement.go
@@ -221,7 +221,7 @@ func (c CreateTableColumnStatement) WriteTo(dst io.Writer) (int64, error) {
 
 func (l *Length) String() string {
 	if l.Decimals.Valid {
-		return fmt.Sprintf("%s, %s", l.Length, l.Decimals)
+		return fmt.Sprintf("%s,%s", l.Length, l.Decimals.Value)
 	}
 	return l.Length
 }

--- a/token.go
+++ b/token.go
@@ -8,6 +8,10 @@ type TokenType int
 type Token struct {
 	Type  TokenType
 	Value string
+	Pos   int
+	Line  int
+	Col   int
+	EOF   bool
 }
 
 func NewToken(t TokenType, v string) *Token {


### PR DESCRIPTION
* [x] lexer を別goroutineで動かすようにした #6
* [x] lexerの基本メソッドを `next()`, `peek()`, `advance()`に変更
* [x] lexerのemitまわりを大幅にリファクタリング
* [x] Tokenが位置情報を持つようになった
* [x] parser に`next()`だけでなく、`peek()`, `advance()`, `rewind()`を実装した。#6
* [x] DECIMAL用に生成されるSQL文が間違ってた
* [x] テストケースを少々追加
* [x] エラーメッセージの生成（特にエラーの位置の報告）

fixes #9