### PR TITLE
Prepare binary release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,0 +1,5 @@
+Changes
+=======
+
+0.0.1 - 09 Jan 2017
+    * First binary release

--- a/Makefile
+++ b/Makefile
@@ -104,5 +104,5 @@ release-files: release-windows-386 release-windows-amd64 release-linux-386 relea
 release-github-token: github_token
 	@echo "file `github_token` is required"
 
-release-upload: release-files
+release-upload: release-files release-github-token
 	ghr -u $(GITHUB_USERNAME) -t $(shell cat github_token) --draft --replace $(VERSION) $(RELEASE_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 GOVERSION=$(shell go version)
 GOOS=$(word 1,$(subst /, ,$(word $(words $(GOVERSION)), $(GOVERSION))))
 GOARCH=$(word 2,$(subst /, ,$(word $(words $(GOVERSION)), $(GOVERSION))))
+VERSION=$(patsubst "%",%,$(lastword $(shell grep 'const Version' schemalex.go)))
+ARTIFACTS_DIR=$(CURDIR)/artifacts/$(VERSION)
+RELEASE_DIR=$(CURDIR)/release/$(VERSION)
+SRC_FILES = $(wildcard *.go model/*.go diff/*.go cmd/schemalex/*.go internal/*/*.go)
+GITHUB_USERNAME=schemalex
 
 installdeps: glide-$(GOOS)-$(GOARCH)/glide
 	PATH=glide-$(GOOS)-$(GOARCH):$(PATH) glide install
 
 glide-$(GOOS)-$(GOARCH):
-	@echo "Creating $(@F)"
+	@echo " * Creating $(@F)"
 	@mkdir -p $(@F)
 	
 glide-$(GOOS)-$(GOARCH)/glide:
@@ -20,3 +25,84 @@ test:
 
 generate:
 	go generate
+
+$(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH):
+	@mkdir -p $@
+
+build: $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH)/schemalex$(SUFFIX)
+
+$(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH)/schemalex$(SUFFIX): $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH) $(SRC_FILES)
+	@echo " * Building binary for $(GOOS)/$(GOARCH)..."
+	@go build -o $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH)/schemalex$(SUFFIX) cmd/schemalex/schemalex.go
+
+all: build-linux-amd64 build-linux-386 build-darwin-amd64 build-darwin-386 build-windows-amd64 build-windows-386
+
+build-windows-amd64:
+	@$(MAKE) build GOOS=windows GOARCH=amd64 SUFFIX=.exe
+
+build-windows-386:
+	@$(MAKE) build GOOS=windows GOARCH=386 SUFFIX=.exe
+
+build-linux-amd64:
+	@$(MAKE) build GOOS=linux GOARCH=amd64
+
+build-linux-386:
+	@$(MAKE) build GOOS=linux GOARCH=386
+
+build-darwin-amd64:
+	@$(MAKE) build GOOS=darwin GOARCH=amd64
+
+build-darwin-386:
+	@$(MAKE) build GOOS=darwin GOARCH=386
+
+$(RELEASE_DIR)/schemalex_$(GOOS)_$(GOARCH):
+	@mkdir -p $@
+
+$(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH)/Changes: $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH) Changes
+	@echo " * Copying Changes..."
+	@cp Changes $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH)
+
+$(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH)/README.md: $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH) README.md
+	@echo " * Copying README.md..."
+	@cp README.md $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH)
+
+release-changes: $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH)/Changes
+release-readme: $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH)/README.md
+
+release-windows-amd64:
+	@$(MAKE) build release-changes release-readme release-zip GOOS=windows GOARCH=amd64
+
+release-windows-386:
+	@$(MAKE) build release-changes release-readme release-zip GOOS=windows GOARCH=386
+
+release-linux-amd64:
+	@$(MAKE) build release-changes release-readme release-targz GOOS=linux GOARCH=amd64
+
+release-linux-386:
+	@$(MAKE) build release-changes release-readme release-targz GOOS=linux GOARCH=386
+
+release-darwin-amd64:
+	@$(MAKE) build release-changes release-readme release-zip GOOS=darwin GOARCH=amd64
+
+release-darwin-386:
+	@$(MAKE) build release-changes release-readme release-zip GOOS=darwin GOARCH=386
+
+release-tarbz: $(RELEASE_DIR)/schemalex_$(GOOS)_$(GOARCH)
+	@echo " * Creating tar.bz for $(GOOS)/$(GOARCH)"
+	@tar -cjf $(RELEASE_DIR)/schemalex_$(GOOS)_$(GOARCH).tar.bz2 -C $(ARTIFACTS_DIR) schemalex_$(GOOS)_$(GOARCH)
+
+release-targz: $(RELEASE_DIR)/schemalex_$(GOOS)_$(GOARCH)
+	@echo " * Creating tar.gz for $(GOOS)/$(GOARCH)"
+	tar -czf $(RELEASE_DIR)/schemalex_$(GOOS)_$(GOARCH).tar.gz -C $(ARTIFACTS_DIR) schemalex_$(GOOS)_$(GOARCH)
+
+release-zip: $(RELEASE_DIR)/schemalex_$(GOOS)_$(GOARCH)
+	@echo " * Creating zip for $(GOOS)/$(GOARCH)"
+	cd $(ARTIFACTS_DIR) && zip -9 $(RELEASE_DIR)/schemalex_$(GOOS)_$(GOARCH).zip schemalex_$(GOOS)_$(GOARCH)/*
+
+release-files: release-windows-386 release-windows-amd64 release-linux-386 release-linux-amd64 release-darwin-386 release-darwin-amd64
+
+release-github-token: github_token
+	@echo "file `github_token` is required"
+
+release-upload: release-files
+	ghr -u $(GITHUB_USERNAME) -t $(shell cat github_token) --draft --replace $(VERSION) $(RELEASE_DIR)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,57 @@ Generate difference sql of two mysql schema
 
 [![Build Status](https://travis-ci.org/schemalex/schemalex.png?branch=master)](https://travis-ci.org/schemalex/schemalex)
 
-### SYNOPSIS
+[![GoDoc](https://godoc.org/github.com/schemalex/schemalex?status.svg)](https://godoc.org/github.com/schemalex/schemalex)
+
+## SYNOPSIS (COMMAND LINE)
+
+Suppose you have an existing SQL schema like the following:
+
+```sql
+CREATE TABLE hoge (
+    id INTEGER NOT NULL AUTO_INCREMENT,
+    PRIMARY KEY (id)
+);
+```
+
+And you want "upgrade" your schema to the following:
+
+
+```sql
+CREATE TABLE hoge (
+    id INTEGER NOT NULL AUTO_INCREMENT,
+    c VARCHAR (20) NOT NULL DEFAULT "hoge",
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE fuga (
+    id INTEGER NOT NULL AUTO_INCREMENT,
+    PRIMARY KEY (id)
+);
+```
+
+Using `schemalex` you can generate a set of commands to perform the migration:
+
+```
+schemalex old.sql new.sql
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE `fuga` (
+`id` INTEGER NOT NULL AUTO_INCREMENT,
+PRIMARY KEY (`id`)
+);
+
+ALTER TABLE `hoge` ADD COLUMN `c` VARCHAR (20) NOT NULL DEFAULT "hoge";
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+COMMIT;
+```
+
+## SYNOPSIS (Using the library)
+
+Below is the equivalent of the previous SYNOPSIS.
 
 ```
 package schemalex_test

--- a/cmd/schemalex/schemalex.go
+++ b/cmd/schemalex/schemalex.go
@@ -1,24 +1,76 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"io"
 	"log"
 	"os"
+	"runtime"
 
 	"github.com/schemalex/schemalex"
 	"github.com/schemalex/schemalex/diff"
+	"github.com/schemalex/schemalex/internal/errors"
 )
 
 func main() {
-	if len(os.Args) != 3 {
-		log.Fatalf("should call schemalex /path/to/before /path/to/after")
-	}
-
-	if err := _main(os.Args[1], os.Args[2]); err != nil {
+	if err := _main(); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func _main(before, after string) error {
+func _main() error {
+	var txn bool
+	var version bool
+	var outfile string
+
+	flag.Usage = func() {
+		fmt.Printf(`schemalex version %s
+
+schemalex -version
+schemalex [options...] /path/to/before /path/to/after
+
+-v            Print out the version and exit
+-o file	      Output the result to the specified file (default: stdout)
+-t[=true]     Enable/Disable transaction in the output (default: true)
+`, schemalex.Version)
+	}
+	flag.BoolVar(&version, "v", false, "")
+	flag.BoolVar(&txn, "t", true, "")
+	flag.StringVar(&outfile, "o", "", "")
+	flag.Parse()
+
+	if version {
+		fmt.Printf(
+			"schemalex version %s, built with go %s for %s/%s\n",
+			schemalex.Version,
+			runtime.Version(),
+			runtime.GOOS,
+			runtime.GOARCH,
+		)
+		return nil
+	}
+
+	if flag.NArg() != 2 {
+		flag.Usage()
+		return errors.New("wrong number of arguments")
+	}
+
+	var dst io.Writer = os.Stdout
+	if len(outfile) > 0 {
+		f, err := os.OpenFile(outfile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			return errors.Wrapf(err, `failed to open file %s for writing`, outfile)
+		}
+		dst = f
+		defer f.Close()
+	}
+
 	p := schemalex.New()
-	return diff.Files(os.Stderr, before, after, diff.WithTransaction(true), diff.WithParser(p))
+	return diff.Files(
+		dst,
+		flag.Arg(0),
+		flag.Arg(1),
+		diff.WithTransaction(txn), diff.WithParser(p),
+	)
 }

--- a/schemalex.go
+++ b/schemalex.go
@@ -2,3 +2,5 @@
 //go:generate go run internal/cmd/gencoltypes/main.go
 
 package schemalex
+
+const Version = "0.0.1"


### PR DESCRIPTION
Builds on top of #11, and fixes #5 

バイナリリリースを作ります。

`-ldflags -X`とかはとりあえず使わない、手動と自動のミックスみたいな感じになってます。便利にしたいならしちゃってください。

# 追加されたmakeアクション

| 名称 | 説明 |
|:-----|:-----|
| build | GOOSとGOARCHを指定して、クロスコンパイルしてくれる。結果は `artifacts/$version/schemalex_$GOOS_$GOARCH/schemalex$SUFFIX` へ書き出される |
| all | サポートする全てのGOOS/GOARCHでbuildを実行する |
| release-changes | Changesを`artifacts/$version/schemalex_$GOOS_$GOARCH/Changesへコピーする` |
| release-readme | README.mdを`artifacts/$version/schemalex_$GOOS_$GOARCH/README.mdへコピーする` |
| release-files | schemalexバイナリ、Changes、README.mdをそれぞれtar.gz/zip等で固めて `release/$version/schemalex_$GOOS_$GOARCH.tar.gz`等に配置する |
| release-upload | ghr を使って、`release/$version` 以下のファイルをgithub releaseにアップロードす る |

# リリース手順

`git tag v$version`とかやっておいて

```
make release-files
```

確認して…

```
make release-upload
```

Github releaseに行き、ドラフトがあるので、そこのメッセージを適時変更して、公開。