### PR TITLE
table column hasComment then COMMENT not incleded.

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -46,6 +46,12 @@ func TestDiff(t *testing.T) {
 			After:  "CREATE TABLE `fuga` ( `id` BIGINT NOT NULL );",
 			Expect: "ALTER TABLE `fuga` CHANGE COLUMN `id` `id` BIGINT NOT NULL;",
 		},
+		// change column with comment
+		{
+			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL );",
+			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL COMMENT 'fuga is good' );",
+			Expect: "ALTER TABLE `fuga` CHANGE COLUMN `id` `id` INTEGER NOT NULL COMMENT 'fuga is good';",
+		},
 		// drop primary key
 		{
 			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`) );",

--- a/format/format.go
+++ b/format/format.go
@@ -226,7 +226,7 @@ func formatTableColumn(dst io.Writer, col model.TableColumn) error {
 	}
 
 	if col.HasComment() {
-		buf.WriteString(" '")
+		buf.WriteString(" COMMENT '")
 		buf.WriteString(col.Comment())
 		buf.WriteByte('\'')
 	}


### PR DESCRIPTION
hotfix

```
$ go test -v ./diff

=== RUN   TestDiff
--- FAIL: TestDiff (0.00s)
        Error Trace:    diff_test.go:94
        Error:          Not equal:
                        expected: "ALTER TABLE `fuga` CHANGE COLUMN `id` `id` INTEGER NOT NULL COMMENT 'fuga is good';"
                        received: "ALTER TABLE `fuga` CHANGE COLUMN `id` `id` INTEGER NOT NULL 'fuga is good';"
        Messages:       result SQL should match
FAIL
exit status 1
FAIL    github.com/schemalex/schemalex/diff     0.018s
```