### PR TITLE
Hotfix/table option with quote

### DIFF
--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -25,8 +25,8 @@ func TestDiff(t *testing.T) {
 		// create table
 		{
 			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL );",
-			After:  "CREATE TABLE `hoge` ( `id` INTEGER NOT NULL ) ENGINE=InnoDB; CREATE TABLE `fuga` ( `id` INTEGER NOT NULL );",
-			Expect: "CREATE TABLE `hoge` (\n`id` INTEGER NOT NULL\n) ENGINE = InnoDB;",
+			After:  "CREATE TABLE `hoge` ( `id` INTEGER NOT NULL ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COMMENT 'table comment'; CREATE TABLE `fuga` ( `id` INTEGER NOT NULL );",
+			Expect: "CREATE TABLE `hoge` (\n`id` INTEGER NOT NULL\n) ENGINE = InnoDB, DEFAULT CHARACTER SET = utf8mb4, COMMENT = 'table comment';",
 		},
 		// drop column
 		{

--- a/format/format.go
+++ b/format/format.go
@@ -60,7 +60,14 @@ func formatTableOption(dst io.Writer, option model.TableOption) error {
 	var buf bytes.Buffer
 	buf.WriteString(option.Key())
 	buf.WriteString(" = ")
-	buf.WriteString(option.Value())
+	switch option.Key() {
+	case "COMMENT", "CONNECTION", "DATA DIRECTOR", "INDEX DIRECTORY", "PASSWORD":
+		buf.WriteByte('\'')
+		buf.WriteString(option.Value())
+		buf.WriteByte('\'')
+	default:
+		buf.WriteString(option.Value())
+	}
 
 	if _, err := buf.WriteTo(dst); err != nil {
 		return err

--- a/format/format.go
+++ b/format/format.go
@@ -60,12 +60,11 @@ func formatTableOption(dst io.Writer, option model.TableOption) error {
 	var buf bytes.Buffer
 	buf.WriteString(option.Key())
 	buf.WriteString(" = ")
-	switch option.Key() {
-	case "COMMENT", "CONNECTION", "DATA DIRECTOR", "INDEX DIRECTORY", "PASSWORD":
+	if option.NeedQuotes() {
 		buf.WriteByte('\'')
 		buf.WriteString(option.Value())
 		buf.WriteByte('\'')
-	default:
+	} else {
 		buf.WriteString(option.Value())
 	}
 

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -19,7 +19,7 @@ func TestFormat(t *testing.T) {
 	col.SetType(model.ColumnTypeInt)
 	table.AddColumn(col)
 
-	opt := model.NewTableOption("ENGINE", "InnoDB")
+	opt := model.NewTableOption("ENGINE", "InnoDB", false)
 	table.AddOption(opt)
 
 	index := model.NewIndex(model.IndexKindPrimaryKey)

--- a/model/interface.go
+++ b/model/interface.go
@@ -153,6 +153,7 @@ type TableOption interface {
 	Stmt
 	Key() string
 	Value() string
+	NeedQuotes() bool
 }
 
 type table struct {
@@ -165,8 +166,9 @@ type table struct {
 }
 
 type tableopt struct {
-	key   string
-	value string
+	key        string
+	value      string
+	needQuotes bool
 }
 
 // NullState describes the possible NULL constraint of a column

--- a/model/table.go
+++ b/model/table.go
@@ -88,7 +88,7 @@ func (t *table) Options() chan TableOption {
 	return ch
 }
 
-// NewTableOption creates a new table option with the given name and value and quarts
+// NewTableOption creates a new table option with the given name, value, and a flag indicating if quoting is necessary
 func NewTableOption(k, v string, q bool) TableOption {
 	return &tableopt{
 		key:        k,

--- a/model/table.go
+++ b/model/table.go
@@ -88,14 +88,16 @@ func (t *table) Options() chan TableOption {
 	return ch
 }
 
-// NewTableOption creates a new table option with the given name and value
-func NewTableOption(k, v string) TableOption {
+// NewTableOption creates a new table option with the given name and value and quarts
+func NewTableOption(k, v string, q bool) TableOption {
 	return &tableopt{
-		key:   k,
-		value: v,
+		key:        k,
+		value:      v,
+		needQuotes: q,
 	}
 }
 
-func (t *tableopt) ID() string    { return "tableopt#" + t.key }
-func (t *tableopt) Key() string   { return t.key }
-func (t *tableopt) Value() string { return t.value }
+func (t *tableopt) ID() string       { return "tableopt#" + t.key }
+func (t *tableopt) Key() string      { return t.key }
+func (t *tableopt) Value() string    { return t.value }
+func (t *tableopt) NeedQuotes() bool { return t.needQuotes }

--- a/parser.go
+++ b/parser.go
@@ -571,7 +571,7 @@ func (p *Parser) parseCreateTableOptionValue(ctx *parseCtx, table model.Table, n
 		if typ != t.Type {
 			continue
 		}
-		table.AddOption(model.NewTableOption(name, t.Value))
+		table.AddOption(model.NewTableOption(name, t.Value, t.Type == SINGLE_QUOTE_IDENT || t.Type == DOUBLE_QUOTE_IDENT))
 		return nil
 	}
 	return newParseError(ctx, t, "expected %v", follow)

--- a/parser.go
+++ b/parser.go
@@ -571,7 +571,12 @@ func (p *Parser) parseCreateTableOptionValue(ctx *parseCtx, table model.Table, n
 		if typ != t.Type {
 			continue
 		}
-		table.AddOption(model.NewTableOption(name, t.Value, t.Type == SINGLE_QUOTE_IDENT || t.Type == DOUBLE_QUOTE_IDENT))
+		var quotes bool
+		switch t.Type {
+		case SINGLE_QUOTE_IDENT, DOUBLE_QUOTE_IDENT:
+			quotes = true
+		}
+		table.AddOption(model.NewTableOption(name, t.Value, quotes))
 		return nil
 	}
 	return newParseError(ctx, t, "expected %v", follow)

--- a/parser_test.go
+++ b/parser_test.go
@@ -105,10 +105,10 @@ primary key (id, c)
 		{
 			Input: `create table hoge (
 id bigint unsigned not null auto_increment
-) ENGINE=InnoDB AUTO_INCREMENT 10 DEFAULT CHARACTER SET = utf8;
+) ENGINE=InnoDB AUTO_INCREMENT 10 DEFAULT CHARACTER SET = utf8 COMMENT = 'hoge comment';
 `,
 			Error:  false,
-			Expect: "CREATE TABLE `hoge` (\n`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT\n) ENGINE = InnoDB, AUTO_INCREMENT = 10, DEFAULT CHARACTER SET = utf8",
+			Expect: "CREATE TABLE `hoge` (\n`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT\n) ENGINE = InnoDB, AUTO_INCREMENT = 10, DEFAULT CHARACTER SET = utf8, COMMENT = 'hoge comment'",
 		},
 		// with key, index
 		{
@@ -185,7 +185,7 @@ id bigint unsigned not null auto_increment
 			Expect: "CREATE TABLE `fuga` (\n`id` INTEGER NOT NULL AUTO_INCREMENT,\nCONSTRAINT `symbol` UNIQUE INDEX `uniq_id` USING BTREE (`id`)\n)",
 		},
 		{
-			Input: "DROP TABLE IF EXISTS `konboi_bug`; CREATE TABLE foo(`id` INT)",
+			Input:  "DROP TABLE IF EXISTS `konboi_bug`; CREATE TABLE foo(`id` INT)",
 			Expect: "CREATE TABLE `foo` (\n`id` INT\n)",
 		},
 	}


### PR DESCRIPTION
Some table options require single quote. (like `COMMENT = 'foo'`)

https://dev.mysql.com/doc/refman/5.6/ja/create-table.html


```
$ go test ./diff
--- FAIL: TestDiff (0.00s)
        Error Trace:    diff_test.go:94
        Error:          Not equal:
                        expected: "CREATE TABLE `hoge` (\n`id` INTEGER NOT NULL\n) ENGINE = InnoDB, DEFAULT CHARACTER SET = utf8mb4, COMMENT = 'table comment';"
                        received: "CREATE TABLE `hoge` (\n`id` INTEGER NOT NULL\n) ENGINE = InnoDB, DEFAULT CHARACTER SET = utf8mb4, COMMENT = table comment;"
        Messages:       result SQL should match
FAIL

$ go test .
--- FAIL: TestParser (0.00s)
        parser_test.go:195: Parsing 'create table hoge (
                id bigint unsigned not null auto_increment
                ) ENGINE=InnoDB AUTO_INCREMENT 10 DEFAULT CHARACTER SET = utf8 COMMENT = 'hoge comment';
                '
        Error Trace:    parser_test.go:212
        Error:          Not equal:
                        expected: "CREATE TABLE `hoge` (\n`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT\n) ENGINE = InnoDB, AUTO_INCREMENT = 10, DEFAULT CHARACTER SET = utf8, COMMENT = 'hoge comment'"
                        received: "CREATE TABLE `hoge` (\n`id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT\n) ENGINE = InnoDB, AUTO_INCREMENT = 10, DEFAULT CHARACTER SET = utf8, COMMENT = hoge comment"
        Messages:       should match
FAIL
```

