### PR TITLE
Hotfix/alter order

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -268,10 +268,10 @@ func newAlterCtx(from, to model.Table) *alterCtx {
 
 func alterTables(ctx *diffCtx, dst io.Writer) (int64, error) {
 	procs := []func(*alterCtx, io.Writer) (int64, error){
+		dropTableIndexes,
 		dropTableColumns,
 		addTableColumns,
 		alterTableColumns,
-		dropTableIndexes,
 		addTableIndexes,
 	}
 

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -82,6 +82,12 @@ func TestDiff(t *testing.T) {
 			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, CONSTRAINT `symbol` UNIQUE KEY `uniq_id` USING BTREE (`id`) );",
 			Expect: "",
 		},
+		// multi modify
+		{
+			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `aid` INTEGER NOT NULL, `bid` INTEGER NOT NULL, INDEX `ab` (`aid`, `bid`) );",
+			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `aid` INTEGER NOT NULL, `cid` INTEGER NOT NULL, INDEX `ac` (`aid`, `cid`) );",
+			Expect: "ALTER TABLE `fuga` DROP INDEX `ab`;\nALTER TABLE `fuga` DROP COLUMN `bid`;\nALTER TABLE `fuga` ADD COLUMN `cid` INTEGER NOT NULL;\nALTER TABLE `fuga` ADD INDEX `ac` (`aid`, `cid`);",
+		},
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
columnとindexをリネームしようとした時に

1. DROP COLUMN
2. ADD COLUMN
3. DROP INDEX (← `Can't DROP 'foo_index'; check that column/key exists`)
4. ADD INDEX

の順でALTERが出力されます。

しかしこの順番だと、3の時に既にINDEXが存在しない場合があります(単一カラムのインデックスの場合)
そこで順番を 下記の用に変更する必要があります

1. DROP INDEX
2. DROP COLUMN
3. ADD COLUMN
4. ADD INDEX

```
--- FAIL: TestDiff (0.00s)
        Error Trace:    diff_test.go:100
        Error:          Not equal:
                        expected: "ALTER TABLE `fuga` DROP INDEX `ab`;\nALTER TABLE `fuga` DROP COLUMN `bid`;\nALTER TABLE `fuga` ADD COLUMN `cid` INTEGER NOT NULL;\nALTER TABLE `fuga` ADD INDEX `ac` (`aid`, `cid`);"
                        received: "ALTER TABLE `fuga` DROP COLUMN `bid`;\nALTER TABLE `fuga` ADD COLUMN `cid` INTEGER NOT NULL;\nALTER TABLE `fuga` DROP INDEX `ab`;\nALTER TABLE `fuga` ADD INDEX `ac` (`aid`, `cid`);"
        Messages:       result SQL should match
FAIL
FAIL    github.com/schemalex/schemalex/diff     0.010s
```

参考 : https://dev.mysql.com/doc/refman/5.6/ja/alter-table.html
> テーブルからカラムが削除された場合、そのカラムは、それが含まれているすべてのインデックスからも削除されます。インデックスを構成するすべてのカラムが削除された場合は、そのインデックスも削除されます。CHANGE または MODIFY を使用して、インデックスが存在するカラムを短くしたときに、結果として得られるカラムの長さがインデックスの長さより短くなった場合、MySQL は自動的にそのインデックスを短くします。
