### PR TITLE
Hotfix/diff nochange foreign key

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -413,7 +413,7 @@ func dropTableIndexes(ctx *alterCtx, dst io.Writer) (int64, error) {
 			continue
 		}
 
-		if !indexStmt.HasName() {
+		if !indexStmt.HasName() && !indexStmt.HasSymbol() {
 			return 0, errors.Errorf("can not drop index without name: %s", indexStmt.ID())
 		}
 
@@ -424,10 +424,19 @@ func dropTableIndexes(ctx *alterCtx, dst io.Writer) (int64, error) {
 		buf.WriteString(ctx.from.Name())
 		if indexStmt.IsForeginKey() {
 			buf.WriteString("` DROP FOREIGN KEY `")
+			if indexStmt.HasSymbol() {
+				buf.WriteString(indexStmt.Symbol())
+			} else {
+				buf.WriteString(indexStmt.Name())
+			}
 		} else {
 			buf.WriteString("` DROP INDEX `")
+			if !indexStmt.HasName() {
+				buf.WriteString(indexStmt.Symbol())
+			} else {
+				buf.WriteString(indexStmt.Name())
+			}
 		}
-		buf.WriteString(indexStmt.Name())
 		buf.WriteString("`;")
 	}
 

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -422,7 +422,11 @@ func dropTableIndexes(ctx *alterCtx, dst io.Writer) (int64, error) {
 		}
 		buf.WriteString("ALTER TABLE `")
 		buf.WriteString(ctx.from.Name())
-		buf.WriteString("` DROP INDEX `")
+		if indexStmt.IsForeginKey() {
+			buf.WriteString("` DROP FOREIGN KEY `")
+		} else {
+			buf.WriteString("` DROP INDEX `")
+		}
 		buf.WriteString(indexStmt.Name())
 		buf.WriteString("`;")
 	}

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -88,6 +88,12 @@ func TestDiff(t *testing.T) {
 			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `fid` INTEGER NOT NULL, FOREIGN KEY fk (fid) REFERENCES f (id) );",
 			Expect: "",
 		},
+		// change CONSTRAINT symbol naml
+		{
+			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `fid` INTEGER NOT NULL, CONSTRAINT `fsym` FOREIGN KEY (fid) REFERENCES f (id) );",
+			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `fid` INTEGER NOT NULL, CONSTRAINT `ksym` FOREIGN KEY (fid) REFERENCES f (id) );",
+			Expect: "ALTER TABLE `fuga` DROP FOREIGN KEY `fsym`;\nALTER TABLE `fuga` ADD CONSTRAINT `ksym` FOREIGN KEY (`fid`) REFERENCES `f` (`id`);",
+		},
 		// remove FOREIGN KEY
 		{
 			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `fid` INTEGER NOT NULL, FOREIGN KEY fk (fid) REFERENCES f (id) );",

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -88,6 +88,12 @@ func TestDiff(t *testing.T) {
 			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `fid` INTEGER NOT NULL, FOREIGN KEY fk (fid) REFERENCES f (id) );",
 			Expect: "",
 		},
+		// remove FOREIGN KEY
+		{
+			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `fid` INTEGER NOT NULL, FOREIGN KEY fk (fid) REFERENCES f (id) );",
+			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `fid` INTEGER NOT NULL, INDEX fid (fid) );",
+			Expect: "ALTER TABLE `fuga` DROP FOREIGN KEY `fk`;\nALTER TABLE `fuga` ADD INDEX `fid` (`fid`);",
+		},
 		// multi modify
 		{
 			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `aid` INTEGER NOT NULL, `bid` INTEGER NOT NULL, INDEX `ab` (`aid`, `bid`) );",

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -82,6 +82,12 @@ func TestDiff(t *testing.T) {
 			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, CONSTRAINT `symbol` UNIQUE KEY `uniq_id` USING BTREE (`id`) );",
 			Expect: "",
 		},
+		// not change FOREIGN KEY
+		{
+			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `fid` INTEGER NOT NULL, FOREIGN KEY fk (fid) REFERENCES f (id) );",
+			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `fid` INTEGER NOT NULL, FOREIGN KEY fk (fid) REFERENCES f (id) );",
+			Expect: "",
+		},
 		// multi modify
 		{
 			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, `aid` INTEGER NOT NULL, `bid` INTEGER NOT NULL, INDEX `ab` (`aid`, `bid`) );",

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -22,7 +22,7 @@ func TestFormat(t *testing.T) {
 	opt := model.NewTableOption("ENGINE", "InnoDB", false)
 	table.AddOption(opt)
 
-	index := model.NewIndex(model.IndexKindPrimaryKey)
+	index := model.NewIndex(model.IndexKindPrimaryKey, table.ID())
 	index.SetName("hoge_pk")
 	index.AddColumns("fuga")
 	table.AddIndex(index)

--- a/model/index.go
+++ b/model/index.go
@@ -3,26 +3,36 @@ package model
 import (
 	"crypto/sha256"
 	"fmt"
-	"io"
 )
 
 // NewIndex creates a new index with the given index kind.
-func NewIndex(kind IndexKind) Index {
+func NewIndex(kind IndexKind, table string) Index {
 	return &index{
-		kind: kind,
+		kind:  kind,
+		table: table,
 	}
 }
 
 func (stmt *index) ID() string {
 	// This is tricky. and index may or may not have a name. It would
 	// have been so much easier if we did, but we don't, so we'll fake
-	// something
+	// something.
+	//
+	// In case we don't have a name, we need to know the table, the kind,
+	// the type, // the column(s), and the reference(s).
 	name := "index"
 	if stmt.HasName() {
 		name = name + "#" + stmt.Name()
 	}
 	h := sha256.New()
-	io.WriteString(h, fmt.Sprintf("%v, %v, %v, %v, %v, %v", stmt.symbol, stmt.kind, stmt.name, stmt.typ, stmt.columns, stmt.reference))
+	fmt.Fprintf(h,
+		"%s.%s.%s.%v.%s",
+		stmt.table,
+		stmt.kind,
+		stmt.typ,
+		stmt.columns,
+		stmt.reference,
+	)
 	return fmt.Sprintf("%s#%x", name, h.Sum(nil))
 }
 

--- a/model/index.go
+++ b/model/index.go
@@ -26,8 +26,9 @@ func (stmt *index) ID() string {
 	}
 	h := sha256.New()
 	fmt.Fprintf(h,
-		"%s.%s.%s.%v.%s",
+		"%s.%s,%s.%s.%v.%s",
 		stmt.table,
+		stmt.Symbol(),
 		stmt.kind,
 		stmt.typ,
 		stmt.columns,

--- a/model/index.go
+++ b/model/index.go
@@ -22,7 +22,7 @@ func (stmt *index) ID() string {
 		name = name + "#" + stmt.Name()
 	}
 	h := sha256.New()
-	io.WriteString(h, fmt.Sprintf("%v", stmt))
+	io.WriteString(h, fmt.Sprintf("%v, %v, %v, %v, %v, %v", stmt.symbol, stmt.kind, stmt.name, stmt.typ, stmt.columns, stmt.reference))
 	return fmt.Sprintf("%s#%x", name, h.Sum(nil))
 }
 

--- a/model/interface.go
+++ b/model/interface.go
@@ -73,6 +73,7 @@ type index struct {
 	kind    IndexKind
 	name    maybeString
 	typ     IndexType
+	table   string
 	columns []string
 	// TODO Options.
 	reference Reference

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -12,5 +12,5 @@ func TestStatement(t *testing.T) {
 	stmts = append(stmts, model.NewDatabase("test"))
 	stmts = append(stmts, model.NewTable("test"))
 	stmts = append(stmts, model.NewTableColumn("test"))
-	stmts = append(stmts, model.NewIndex(model.IndexKindPrimaryKey))
+	stmts = append(stmts, model.NewIndex(model.IndexKindPrimaryKey, stmts[1].ID()))
 }

--- a/parser.go
+++ b/parser.go
@@ -360,17 +360,17 @@ func (p *Parser) parseTableConstraint(ctx *parseCtx, table model.Table) error {
 	var index model.Index
 	switch t := ctx.peek(); t.Type {
 	case PRIMARY:
-		index = model.NewIndex(model.IndexKindPrimaryKey)
+		index = model.NewIndex(model.IndexKindPrimaryKey, table.ID())
 		if err := p.parseColumnIndexPrimaryKey(ctx, index); err != nil {
 			return err
 		}
 	case UNIQUE:
-		index = model.NewIndex(model.IndexKindUnique)
+		index = model.NewIndex(model.IndexKindUnique, table.ID())
 		if err := p.parseColumnIndexUniqueKey(ctx, index); err != nil {
 			return err
 		}
 	case FOREIGN:
-		index = model.NewIndex(model.IndexKindForeignKey)
+		index = model.NewIndex(model.IndexKindForeignKey, table.ID())
 		if err := p.parseColumnIndexForeignKey(ctx, index); err != nil {
 			return err
 		}
@@ -387,7 +387,7 @@ func (p *Parser) parseTableConstraint(ctx *parseCtx, table model.Table) error {
 }
 
 func (p *Parser) parseTablePrimaryKey(ctx *parseCtx, table model.Table) error {
-	index := model.NewIndex(model.IndexKindPrimaryKey)
+	index := model.NewIndex(model.IndexKindPrimaryKey, table.ID())
 	if err := p.parseColumnIndexPrimaryKey(ctx, index); err != nil {
 		return err
 	}
@@ -396,7 +396,7 @@ func (p *Parser) parseTablePrimaryKey(ctx *parseCtx, table model.Table) error {
 }
 
 func (p *Parser) parseTableUniqueKey(ctx *parseCtx, table model.Table) error {
-	index := model.NewIndex(model.IndexKindUnique)
+	index := model.NewIndex(model.IndexKindUnique, table.ID())
 	if err := p.parseColumnIndexUniqueKey(ctx, index); err != nil {
 		return err
 	}
@@ -405,7 +405,7 @@ func (p *Parser) parseTableUniqueKey(ctx *parseCtx, table model.Table) error {
 }
 
 func (p *Parser) parseTableIndex(ctx *parseCtx, table model.Table) error {
-	index := model.NewIndex(model.IndexKindNormal)
+	index := model.NewIndex(model.IndexKindNormal, table.ID())
 	if err := p.parseColumnIndexKey(ctx, index); err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func (p *Parser) parseTableIndex(ctx *parseCtx, table model.Table) error {
 }
 
 func (p *Parser) parseTableFulltextIndex(ctx *parseCtx, table model.Table) error {
-	index := model.NewIndex(model.IndexKindFullText)
+	index := model.NewIndex(model.IndexKindFullText, table.ID())
 	if err := p.parseColumnIndexFullTextKey(ctx, index); err != nil {
 		return err
 	}
@@ -423,7 +423,7 @@ func (p *Parser) parseTableFulltextIndex(ctx *parseCtx, table model.Table) error
 }
 
 func (p *Parser) parseTableSpatialIndex(ctx *parseCtx, table model.Table) error {
-	index := model.NewIndex(model.IndexKindSpatial)
+	index := model.NewIndex(model.IndexKindSpatial, table.ID())
 	if err := p.parseColumnIndexSpatialKey(ctx, index); err != nil {
 		return err
 	}
@@ -432,7 +432,7 @@ func (p *Parser) parseTableSpatialIndex(ctx *parseCtx, table model.Table) error 
 }
 
 func (p *Parser) parseTableForeignKey(ctx *parseCtx, table model.Table) error {
-	index := model.NewIndex(model.IndexKindForeignKey)
+	index := model.NewIndex(model.IndexKindForeignKey, table.ID())
 	if err := p.parseColumnIndexForeignKey(ctx, index); err != nil {
 		return err
 	}


### PR DESCRIPTION
FOREIGN KEY利用において二つの問題が有りました。

1. 137126279e954e2b4f4b4fa68f6f52c66f514c5e
   * FOREIGN KEYを利用すると、変更が無くても常にdiffが表示されます
2. ccd2928a70fad0a368d91c790517e31b703cc5a3
   * FOREIGN KEYのDROPが`DROP INDEX`になっていたため削除されません

## 対応

1 については Indexの`ID()` において、structのhash値を利用しておりますが、そこにポインタが含まれていたため、値が同じであっても、ポインタが異なる場合(fromとtoで)diffが出ておりました。
(ちょっと泥臭いのでもっと良いやり方があれば是非教えてください！）

2 については対応漏れでしたので追加いたしました。