### PR TITLE
Allow more flexible schema sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.7.4
+  - 1.9
   - tip
 install:
   - make installdeps

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ schemalex [options...] before after
 -t[=true]     Enable/Disable transaction in the output (default: true)
 
 "before" and "after" may be a file path, or a URI.
-Special URI schemes "mysql", "local-git", are supported on top of
+Special URI schemes "mysql" and "local-git" are supported on top of
 "file". If the special path "-" is used, it is treated as stdin
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # schemalex
 
-Generate difference of two mysql schema
+Generate the difference of two mysql schema
 
 [![Build Status](https://travis-ci.org/schemalex/schemalex.png?branch=master)](https://travis-ci.org/schemalex/schemalex)
 
 [![GoDoc](https://godoc.org/github.com/schemalex/schemalex?status.svg)](https://godoc.org/github.com/schemalex/schemalex)
 
-## SYNOPSIS (COMMAND LINE)
+## SYNOPSIS
+
+This tool can be used to generate the difference, or more precisely,
+the statements required to migrate from/to, between two MySQL
+schema.
 
 Suppose you have an existing SQL schema like the following:
 
@@ -50,6 +54,41 @@ ALTER TABLE `hoge` ADD COLUMN `c` VARCHAR (20) NOT NULL DEFAULT "hoge";
 SET FOREIGN_KEY_CHECKS = 1;
 
 COMMIT;
+```
+
+You can also use URI formatted strings as the sources to compare,
+which allow you to compare local files against online schema,
+a version committed to your git repository against another version,
+etc.
+
+Please see the help command for a list
+
+```
+schemalex -version
+schemalex [options...] before after
+
+-v            Print out the version and exit
+-o file	      Output the result to the specified file (default: stdout)
+-t[=true]     Enable/Disable transaction in the output (default: true)
+
+"before" and "after" may be a file path, or a URI.
+Special URI schemes "mysql", "local-git", are supported on top of
+"file". If the special path "-" is used, it is treated as stdin
+
+Examples:
+
+* Compare local files
+  schemalex /path/to/file /another/path/to/file
+  schemalex file:///path/to/file /another/path/to/file
+
+* Compare local file against online mysql schema
+  schemalex /path/to/file "mysql://user:password@tcp(host:port)/dbname?option=value"
+
+* Compare file in local git repository against local file
+  schemalex local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf /path/to/file
+
+* Compare schema from stdin against local file
+	.... | schemalex - /path/to/file
 ```
 
 ## SYNOPSIS (Using the library)

--- a/cmd/schemalex/schemalex.go
+++ b/cmd/schemalex/schemalex.go
@@ -35,8 +35,8 @@ schemalex [options...] before after
 -t[=true]     Enable/Disable transaction in the output (default: true)
 
 "before" and "after" may be a file path, or a URI.
-A special URI schema "mysql" may be used to indicate to retrieve the
-schema definition from a database.
+Special URI schemes "mysql", "local-git", are supported on top of
+"file". If the special path "-" is used, it is treated as stdin
 
 Examples:
 

--- a/cmd/schemalex/schemalex.go
+++ b/cmd/schemalex/schemalex.go
@@ -39,8 +39,19 @@ A special URI schema "mysql" may be used to indicate to retrieve the
 schema definition from a database.
 
 Examples:
+
+* Compare local files
   schemalex /path/to/file /another/path/to/file
+	schemalex file:///path/to/file /another/path/to/file
+
+* Compare local file against online mysql schema
   schemalex /path/to/file "mysql://user:password@tcp(host:port)/dbname?option=value"
+
+* Compare file in local git repository against local file
+  schemalex local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf /path/to/file
+
+* Compare schema from stdin against local file
+	.... | schemalex - /path/to/file
 
 `, schemalex.Version)
 	}

--- a/cmd/schemalex/schemalex.go
+++ b/cmd/schemalex/schemalex.go
@@ -35,7 +35,7 @@ schemalex [options...] before after
 -t[=true]     Enable/Disable transaction in the output (default: true)
 
 "before" and "after" may be a file path, or a URI.
-Special URI schemes "mysql", "local-git", are supported on top of
+Special URI schemes "mysql" and "local-git" are supported on top of
 "file". If the special path "-" is used, it is treated as stdin
 
 Examples:

--- a/cmd/schemalex/schemalex.go
+++ b/cmd/schemalex/schemalex.go
@@ -42,7 +42,7 @@ Examples:
 
 * Compare local files
   schemalex /path/to/file /another/path/to/file
-	schemalex file:///path/to/file /another/path/to/file
+  schemalex file:///path/to/file /another/path/to/file
 
 * Compare local file against online mysql schema
   schemalex /path/to/file "mysql://user:password@tcp(host:port)/dbname?option=value"

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -155,27 +155,7 @@ func Strings(dst io.Writer, from, to string, options ...Option) error {
 // of statements to migrate from the old one to the new one,
 // writing the result to `dst`
 func Files(dst io.Writer, from, to string, options ...Option) error {
-	var p *schemalex.Parser
-	for _, o := range options {
-		switch o.Name() {
-		case "parser":
-			p = o.Value().(*schemalex.Parser)
-		}
-	}
-	if p == nil {
-		p = schemalex.New()
-	}
-	stmts1, err := p.ParseFile(from)
-	if err != nil {
-		return errors.Wrapf(err, `failed to open "from" file %s`, from)
-	}
-
-	stmts2, err := p.ParseFile(to)
-	if err != nil {
-		return errors.Wrapf(err, `failed to open "to" file %s`, to)
-	}
-
-	return Statements(dst, stmts1, stmts2, options...)
+	return Sources(dst, schemalex.NewLocalFileSource(from), schemalex.NewLocalFileSource(to), options...)
 }
 
 func Sources(dst io.Writer, from, to schemalex.SchemaSource, options ...Option) error {

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -158,6 +158,9 @@ func Files(dst io.Writer, from, to string, options ...Option) error {
 	return Sources(dst, schemalex.NewLocalFileSource(from), schemalex.NewLocalFileSource(to), options...)
 }
 
+// Files compares contents from two sources and generates a series
+// of statements to migrate from the old one to the new one,
+// writing the result to `dst`
 func Sources(dst io.Writer, from, to schemalex.SchemaSource, options ...Option) error {
 	var buf bytes.Buffer
 	if err := from.WriteSchema(&buf); err != nil {

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -178,6 +178,20 @@ func Files(dst io.Writer, from, to string, options ...Option) error {
 	return Statements(dst, stmts1, stmts2, options...)
 }
 
+func Sources(dst io.Writer, from, to schemalex.SchemaSource, options ...Option) error {
+	var buf bytes.Buffer
+	if err := from.WriteSchema(&buf); err != nil {
+		return errors.Wrapf(err, `failed to retrieve schema from "from" source %s`, from)
+	}
+	fromStr := buf.String()
+	buf.Reset()
+
+	if err := to.WriteSchema(&buf); err != nil {
+		return errors.Wrapf(err, `failed to retrieve schema from "to" source %s`, to)
+	}
+	return Strings(dst, fromStr, buf.String(), options...)
+}
+
 func dropTables(ctx *diffCtx, dst io.Writer) (int64, error) {
 	var buf bytes.Buffer
 	ids := ctx.fromSet.Difference(ctx.toSet)

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 653e5e93d2b773a793f9fb9a17855b4d081f35f1cbe1913e3c78bbeaae07e646
-updated: 2017-09-20T10:28:35.785261093+09:00
+hash: acd8b288de04336f293759ee9697b270fb2b8228696c0d80c7d06e35fc98b4a1
+updated: 2017-10-06T20:50:32.803347651+09:00
 imports:
 - name: github.com/deckarep/golang-set
   version: b3af78e1d186c53529e3c916055d734665f68121
+- name: github.com/go-sql-driver/mysql
+  version: a0583e0143b1624142adab07e0e97fe106d99561
 - name: github.com/pkg/errors
   version: 2b3a18b5f0fb6b4f9190549597d3f962c02bc5eb
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,8 @@ package: github.com/schemalex/schemalex
 import:
 - package: github.com/deckarep/golang-set
 - package: github.com/pkg/errors
+- package: github.com/go-sql-driver/mysql
+  version: v1.3
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/source.go
+++ b/source.go
@@ -85,6 +85,16 @@ func NewReaderSource(src io.Reader) SchemaSource {
 
 // NewMySQLSource creates a SchemaSource whose contents are derived by
 // accessing the specified MySQL instance.
+//
+// MySQL sources respect extra parameters "ssl-ca", "ssl-cert", and
+// "ssl-secret" (which all should point to local file names) when
+// the "tls" parameter is set to some boolean true value. In this
+// case, we register the given tls configuration using those values
+// automatically.
+//
+// Please note that the "tls" parameter MUST BE A BOOLEAN. Otherwise
+// we expect that you have already registered your tls configuration
+// manually, and that you gave us the name of that configuration
 func NewMySQLSource(s string) SchemaSource {
 	return mysqlSource(s)
 }
@@ -113,12 +123,6 @@ func (s *readerSource) WriteSchema(dst io.Writer) error {
 }
 
 // MySQLConfig creates a *mysql.Config struct from the given DSN.
-//
-// On top of just calling mysql.ParseDSN, we check for extra parameters
-// "ssl-ca", "ssl-cert", and "ssl-secret" (which all should point to
-// local file names) when the "tls" parameter is set to some boolean
-// true value. In this case, we register the given tls configuration
-// using those values automatically.
 func (s mysqlSource) MySQLConfig() (*mysql.Config, error) {
 	cfg, err := mysql.ParseDSN(string(s))
 	if err != nil {

--- a/source.go
+++ b/source.go
@@ -1,0 +1,140 @@
+package schemalex
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/schemalex/schemalex/internal/errors"
+)
+
+type SchemaSource interface {
+	WriteSchema(io.Writer) error
+}
+
+type mysqlSource string
+
+type localFileSource string
+
+func NewSchemaSource(uri string) (SchemaSource, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to parse uri`)
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "mysql":
+		// Treat the argument as a DSN for mysql.
+		// DSN is everything after "mysql://", so let's be lazy
+		// and use everything after the second slash
+		return mysqlSource(uri[8:]), nil
+	case "file", "":
+		// Eh, no remote host, please
+		if u.Host != "" && u.Host != "localhost" {
+			return nil, errors.Wrap(err, `remote hosts for file:// sources are not supported`)
+		}
+
+		return localFileSource(u.Path), nil
+	}
+
+	return nil, errors.New("invalid source")
+}
+
+func (s mysqlSource) open() (*sql.DB, error) {
+	// attempt to open connection to mysql
+	cfg, err := mysql.ParseDSN(string(s))
+	if err != nil {
+		return nil, errors.Wrap(err, `failed to parse DSN`)
+	}
+
+	// because _I_ need support for tls, I'm going to handle setting up
+	// the tls stuff, by using
+	// tls=true&ssl-ca=file=...&ssl-cert=...&ssql-secret=...
+	if v, err := strconv.ParseBool(cfg.TLSConfig); err == nil && v {
+		sslCa := cfg.Params["ssl-ca"]
+		sslCert := cfg.Params["ssl-cert"]
+		sslSecret := cfg.Params["ssl-secret"]
+		if sslCa == "" || sslCert == "" || sslSecret == "" {
+			return nil, errors.New(`to enable tls, you must provide ssl-ca, ssl-cert, and ssl-secret parameters to the DSN`)
+		}
+
+		tlsName := "custom-tls"
+		rootCertPool := x509.NewCertPool()
+		pem, err := ioutil.ReadFile(sslCa)
+		if err != nil {
+			return nil, errors.Wrap(err, `failed to read ssl-ca file`)
+		}
+		if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+			return nil, errors.New(`failed to append ssl-ca PEM to cert pool`)
+		}
+		certs, err := tls.LoadX509KeyPair(sslCert, sslSecret)
+		if err != nil {
+			return nil, errors.Wrap(err, `failed to load X509 key pair`)
+		}
+		mysql.RegisterTLSConfig(tlsName, &tls.Config{
+			RootCAs:      rootCertPool,
+			Certificates: []tls.Certificate{certs},
+		})
+		cfg.TLSConfig = tlsName
+	}
+
+	return sql.Open("mysql", cfg.FormatDSN())
+}
+
+func (s localFileSource) WriteSchema(dst io.Writer) error {
+	f, err := os.Open(string(s))
+	if err != nil {
+		return errors.Wrapf(err, `failed to open local file %s`, s)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(dst, f); err != nil {
+		return errors.Wrap(err, `failed to copy file contents to dst`)
+	}
+	return nil
+}
+
+func (s mysqlSource) WriteSchema(dst io.Writer) error {
+	db, err := s.open()
+	if err != nil {
+		return errors.Wrap(err, `failed to open connection to database`)
+	}
+	defer db.Close()
+
+	tableRows, err := db.Query("SHOW TABLES")
+	if err != nil {
+		return errors.Wrap(err, `failed to execute 'SHOW TABLES'`)
+	}
+	defer tableRows.Close()
+
+	var table string
+	var tableSchema string
+	var buf bytes.Buffer
+	for tableRows.Next() {
+		if err = tableRows.Scan(&table); err != nil {
+			return errors.Wrap(err, `failed to scan tables`)
+		}
+
+		if err = db.QueryRow("SHOW CREATE TABLE `"+table+"`").Scan(&table, &tableSchema); err != nil {
+			return errors.Wrapf(err, `failed to execute 'SHOW CREATE TABLE "%s"'`, table)
+		}
+		if buf.Len() > 0 {
+			buf.WriteString("\n\n")
+		}
+		// TODO remove dynamic info. ex) AUTO_INCREMENT,PARTITION
+		buf.WriteString(tableSchema)
+		buf.WriteByte(';')
+	}
+	if _, err := buf.WriteTo(dst); err != nil {
+		return errors.Wrap(err, `failed to write schema to dst`)
+	}
+	return nil
+}

--- a/source.go
+++ b/source.go
@@ -35,17 +35,24 @@ func NewSchemaSource(uri string) (SchemaSource, error) {
 		// Treat the argument as a DSN for mysql.
 		// DSN is everything after "mysql://", so let's be lazy
 		// and use everything after the second slash
-		return mysqlSource(uri[8:]), nil
+		return NewMySQLSource(uri[8:]), nil
 	case "file", "":
 		// Eh, no remote host, please
 		if u.Host != "" && u.Host != "localhost" {
 			return nil, errors.Wrap(err, `remote hosts for file:// sources are not supported`)
 		}
-
-		return localFileSource(u.Path), nil
+		return NewLocalFileSource(u.Path), nil
 	}
 
 	return nil, errors.New("invalid source")
+}
+
+func NewMySQLSource(s string) SchemaSource {
+	return mysqlSource(s)
+}
+
+func NewLocalFileSource(s string) SchemaSource {
+	return localFileSource(s)
 }
 
 func (s mysqlSource) open() (*sql.DB, error) {

--- a/source_test.go
+++ b/source_test.go
@@ -200,7 +200,7 @@ func TestSchemaSource(t *testing.T) {
 					if !assert.NoError(t, err, "should be able to parse DSN") {
 						return false
 					}
-					if !assert.Equal(t, cfg.TLSConfig, "custom-tls", "TLSConfig should be enabled") {
+					if !assert.True(t, strings.HasPrefix(cfg.TLSConfig, "custom-tls"), "TLSConfig should be enabled") {
 						return false
 					}
 

--- a/source_test.go
+++ b/source_test.go
@@ -1,0 +1,263 @@
+package schemalex
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func generateCertificate(host string, certFile, secretFile io.Writer, isCA bool) error {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * time.Hour)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Schemalex Group"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	hosts := strings.Split(host, ",")
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	if isCA {
+		template.IsCA = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return err
+	}
+
+	pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	pem.Encode(secretFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	return nil
+
+}
+
+func TestSchemaSource(t *testing.T) {
+	certFile, err := ioutil.TempFile("", "schemalex-cert-")
+	if !assert.NoError(t, err, "creating temporary file should succeed") {
+		return
+	}
+	defer certFile.Close()
+	defer os.Remove(certFile.Name())
+
+	secretFile, err := ioutil.TempFile("", "schemalex-secret-")
+	if !assert.NoError(t, err, "creating temporary file should succeed") {
+		return
+	}
+	defer secretFile.Close()
+	defer os.Remove(secretFile.Name())
+
+	caCertFile, err := ioutil.TempFile("", "schemalex-ca-")
+	if !assert.NoError(t, err, "creating temporary file should succeed") {
+		return
+	}
+	defer caCertFile.Close()
+	defer os.Remove(caCertFile.Name())
+
+	if !assert.NoError(t, generateCertificate("schemalex.github.io", certFile, secretFile, false), "generating certificates should succeed") {
+		return
+	}
+	if !assert.NoError(t, generateCertificate("schemalex.github.io", caCertFile, ioutil.Discard, true), "generating server CA should succeed") {
+		return
+	}
+
+	type checker func(s SchemaSource) bool
+
+	testcases := []struct {
+		Input string
+		Check []checker
+		Error bool
+	}{
+		{
+			Input: "/path/to/source.sql",
+			Check: []checker{
+				func(s SchemaSource) bool {
+					lfs, ok := s.(localFileSource)
+					if !assert.True(t, ok, `expected source to be a local file source, got %T`, s) {
+						return false
+					}
+					if !assert.Equal(t, "/path/to/source.sql", string(lfs), "paths should match") {
+						return false
+					}
+					return true
+				},
+			},
+		},
+		{
+			Input: "file:///path/to/source.sql",
+			Check: []checker{
+				func(s SchemaSource) bool {
+					lfs, ok := s.(localFileSource)
+					if !assert.True(t, ok, `expected source to be a local file source, got %T`, s) {
+						return false
+					}
+					if !assert.Equal(t, "/path/to/source.sql", string(lfs), "paths should match") {
+						return false
+					}
+					return true
+				},
+			},
+		},
+		{
+			Input: "-",
+			Check: []checker{
+				func(s SchemaSource) bool {
+					_, ok := s.(*readerSource)
+					if !assert.True(t, ok, `expected source to be reader source, got %T`, s) {
+						return false
+					}
+					return true
+				},
+			},
+		},
+		{
+			Input: "mysql://user:pass@tcp(1.2.3.4:9999)/dbname",
+			Check: []checker{
+				func(s SchemaSource) bool {
+					_, ok := s.(mysqlSource)
+					if !assert.True(t, ok, `expected source to be mysql source, got %T`, s) {
+						return false
+					}
+					return true
+				},
+			},
+		},
+		{
+			Input: "mysql://user:pass@tcp(1.2.3.4:9999)/dbname?tls=true",
+			Check: []checker{
+				func(s SchemaSource) bool {
+					ms, ok := s.(mysqlSource)
+					if !assert.True(t, ok, `expected source to be mysql source, got %T`, s) {
+						return false
+					}
+
+					_, err := ms.MySQLConfig()
+					if !assert.Error(t, err, "should error, because no tls configuration is provided") {
+						return false
+					}
+
+					return true
+				},
+			},
+		},
+		{
+			Input: fmt.Sprintf(
+				"mysql://user:pass@tcp(1.2.3.4:9999)/dbname?tls=true&ssl-ca=%s&ssl-cert=%s&ssl-secret=%s",
+				url.QueryEscape(caCertFile.Name()),
+				url.QueryEscape(certFile.Name()),
+				url.QueryEscape(secretFile.Name()),
+			),
+			Check: []checker{
+				func(s SchemaSource) bool {
+					ms, ok := s.(mysqlSource)
+					if !assert.True(t, ok, `expected source to be mysql source, got %T`, s) {
+						return false
+					}
+
+					cfg, err := ms.MySQLConfig()
+					if !assert.NoError(t, err, "should be able to parse DSN") {
+						return false
+					}
+					if !assert.Equal(t, cfg.TLSConfig, "custom-tls", "TLSConfig should be enabled") {
+						return false
+					}
+
+					return true
+				},
+			},
+		},
+		{
+			Input: "local-git:///path/to/dir?file=foo/baz.sql&commitish=deadbeaf",
+			Check: []checker{
+				func(s SchemaSource) bool {
+					lgs, ok := s.(*localGitSource)
+					if !assert.True(t, ok, `expected source to be local git source, got %T`, s) {
+						return false
+					}
+
+					if !assert.Equal(t, "/path/to/dir", lgs.dir, "directory should match") {
+						return false
+					}
+					if !assert.Equal(t, "foo/baz.sql", lgs.file, "file should match") {
+						return false
+					}
+					if !assert.Equal(t, "deadbeaf", lgs.commitish, "commit ID should match") {
+						return false
+					}
+					return true
+				},
+			},
+		},
+		{Input: "https://github.com/schemalex/schemalex", Error: true},
+	}
+
+	for _, c := range testcases {
+		t.Run(fmt.Sprintf("Parse %s", strconv.Quote(c.Input)), func(t *testing.T) {
+			s, err := NewSchemaSource(c.Input)
+			if c.Error {
+				assert.Error(t, err, "expected '%s' to result in an error")
+
+				// if we expected an error, we have nothing more to do in this
+				// particular test case regardless of the previous assert
+				return
+
+			}
+
+			if !assert.NoError(t, err, "expected '%s' to successfully parse") {
+				return
+			}
+
+			if len(c.Check) == 0 {
+				return
+			}
+
+			for _, check := range c.Check {
+				if !check(s) {
+					return
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds schemalex.SchemaSource, which is an abstraction
over things where you can retrieve the schema definitions from.

As of this change, you can either get the schema from a local file,
or through a mysql DSN.

Examples:

Backwards compatible, local files:

```
  schemalex /path/to/before.sql /path/to/after.sql
```

Use a URI scheme to achieve the same thing:

```
  schemalex file:///path/to/before.sql file:///path/to/after.sql
```

Compare local file against the definition in a running MySQL:

```
  schemalex /path/to/local.sql 'mysql://user:password@tcp(host:port)/dbname'
```