### PR TITLE
bool as tinyint(1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/*
+glide-*-*/glide

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ cache:
     - glide-$(go version | awk '{ print $NF }' | tr '/' '-')
 before_script:
   - make generate
-  - git diff | test -z
 script:
   - make test
+  - make check-diff

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ test:
 generate:
 	go generate
 
+check-diff:
+	@./scripts/check-diff.sh
+
 $(ARTIFACTS_DIR)/schemalex_$(GOOS)_$(GOARCH):
 	@mkdir -p $@
 

--- a/internal/cmd/gencoltypes/main.go
+++ b/internal/cmd/gencoltypes/main.go
@@ -31,6 +31,8 @@ func _main() error {
 		"Integer": "Int",
 		"Numeric": "Decimal",
 		"Real":    "Double",
+		"Bool":    "TinyInt",
+		"Boolean": "TinyInt",
 	}
 
 	types := []string{

--- a/internal/cmd/gencoltypes/main.go
+++ b/internal/cmd/gencoltypes/main.go
@@ -7,6 +7,7 @@ import (
 	"go/format"
 	"log"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -105,9 +106,16 @@ func _main() error {
 	buf.WriteString("\n// If the type does not have a synonym then this method returns the receiver itself")
 	buf.WriteString("\nfunc (c ColumnType) SynonymType() ColumnType {")
 	buf.WriteString("\nswitch c {")
-	for from, to := range synonyms {
+
+	var synonymKeys []string
+	for from := range synonyms {
+		synonymKeys = append(synonymKeys, from)
+	}
+	sort.Strings(synonymKeys)
+
+	for _, from := range synonymKeys {
 		buf.WriteString("\ncase ColumnType" + from + ":")
-		buf.WriteString("\nreturn ColumnType" + to)
+		buf.WriteString("\nreturn ColumnType" + synonyms[from])
 	}
 	buf.WriteString("\n}")
 	buf.WriteString("\nreturn c")

--- a/model/columns_gen.go
+++ b/model/columns_gen.go
@@ -122,12 +122,16 @@ func (c ColumnType) String() string {
 // If the type does not have a synonym then this method returns the receiver itself
 func (c ColumnType) SynonymType() ColumnType {
 	switch c {
-	case ColumnTypeReal:
-		return ColumnTypeDouble
+	case ColumnTypeBoolean:
+		return ColumnTypeTinyInt
 	case ColumnTypeInteger:
 		return ColumnTypeInt
 	case ColumnTypeNumeric:
 		return ColumnTypeDecimal
+	case ColumnTypeReal:
+		return ColumnTypeDouble
+	case ColumnTypeBool:
+		return ColumnTypeTinyInt
 	}
 	return c
 }

--- a/model/columns_gen.go
+++ b/model/columns_gen.go
@@ -122,6 +122,8 @@ func (c ColumnType) String() string {
 // If the type does not have a synonym then this method returns the receiver itself
 func (c ColumnType) SynonymType() ColumnType {
 	switch c {
+	case ColumnTypeBool:
+		return ColumnTypeTinyInt
 	case ColumnTypeBoolean:
 		return ColumnTypeTinyInt
 	case ColumnTypeInteger:
@@ -130,8 +132,6 @@ func (c ColumnType) SynonymType() ColumnType {
 		return ColumnTypeDecimal
 	case ColumnTypeReal:
 		return ColumnTypeDouble
-	case ColumnTypeBool:
-		return ColumnTypeTinyInt
 	}
 	return c
 }

--- a/model/table_column.go
+++ b/model/table_column.go
@@ -261,6 +261,9 @@ func (t *tablecol) NativeLength() Length {
 	}
 	var size int
 	switch t.Type() {
+	case ColumnTypeBool, ColumnTypeBoolean:
+		// bool and boolean is tinyint(1)
+		size = 1
 	case ColumnTypeTinyInt:
 		size = 4 - unsigned
 	case ColumnTypeSmallInt:
@@ -323,6 +326,13 @@ func (t *tablecol) Normalize() (TableColumn, bool) {
 			if t.IsQuotedDefault() {
 				clone = true
 				removeQuotes = true
+			}
+		case ColumnTypeBool, ColumnTypeBoolean:
+			switch t.Default() {
+			case "TRUE":
+				t.SetDefault("1", false)
+			case "FALSE":
+				t.SetDefault("0", false)
 			}
 		}
 	} else {

--- a/model/table_column_test.go
+++ b/model/table_column_test.go
@@ -108,7 +108,10 @@ func TestTableColumnNormalize(t *testing.T) {
 		t.Run(fmt.Sprintf("from %s to %s", beforeStr, afterStr), func(t *testing.T) {
 			norm, _ := tc.before.Normalize()
 			if !assert.Equal(t, norm, tc.after, "Unexpected return value.") {
-				t.Logf("before: %s", beforeStr)
+				buf.Reset()
+				format.SQL(&buf, norm)
+				normStr := buf.String()
+				t.Logf("before: %s normlized: %s", beforeStr, normStr)
 				t.Logf("after: %s", afterStr)
 			}
 		})

--- a/model/table_column_test.go
+++ b/model/table_column_test.go
@@ -109,65 +109,6 @@ func TestTableColumnNormalize(t *testing.T) {
 				SetNullState(model.NullStateNone).
 				SetDefault("NULL", false),
 		},
-		{
-			// foo BOOL DEFAULT TRUE,
-			before: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeBool).
-				SetDefault("TRUE", false),
-			// foo TINYINT(1) DEFAULT 1,
-			after: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeTinyInt).
-				SetLength(model.NewLength("1")).
-				SetNullState(model.NullStateNone).
-				SetDefault("1", false),
-		},
-		{
-			// foo BOOL DEFAULT FALSE,
-			before: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeBool).
-				SetDefault("FALSE", false),
-			// foo TINYINT(1) DEFAULT 0,
-			after: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeTinyInt).
-				SetLength(model.NewLength("1")).
-				SetNullState(model.NullStateNone).
-				SetDefault("0", false),
-		},
-		{
-			// foo BOOLEAN
-			before: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeBoolean),
-			// foo TINYINT(1) DEFAULT NULL,
-			after: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeTinyInt).
-				SetLength(model.NewLength("1")).
-				SetNullState(model.NullStateNone).
-				SetDefault("NULL", false),
-		},
-		{
-			// foo BOOLEAN DEFAULT TRUE
-			before: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeBoolean).
-				SetDefault("TRUE", false),
-			// foo TINYINT(1) DEFAULT 1,
-			after: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeTinyInt).
-				SetLength(model.NewLength("1")).
-				SetNullState(model.NullStateNone).
-				SetDefault("1", false),
-		},
-		{
-			// foo BOOLEAN DEFAULT FALSE
-			before: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeBoolean).
-				SetDefault("FALSE", false),
-			// foo TINYINT(1) DEFAULT 0,
-			after: model.NewTableColumn("foo").
-				SetType(model.ColumnTypeTinyInt).
-				SetLength(model.NewLength("1")).
-				SetNullState(model.NullStateNone).
-				SetDefault("0", false),
-		},
 	} {
 		var buf bytes.Buffer
 		format.SQL(&buf, tc.before)

--- a/model/table_column_test.go
+++ b/model/table_column_test.go
@@ -98,6 +98,76 @@ func TestTableColumnNormalize(t *testing.T) {
 			after: model.NewTableColumn("foo").
 				SetType(model.ColumnTypeText),
 		},
+		{
+			// foo BOOL,
+			before: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeBool),
+			// foo TINYINT(1) DEFAULT NULL,
+			after: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeTinyInt).
+				SetLength(model.NewLength("1")).
+				SetNullState(model.NullStateNone).
+				SetDefault("NULL", false),
+		},
+		{
+			// foo BOOL DEFAULT TRUE,
+			before: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeBool).
+				SetDefault("TRUE", false),
+			// foo TINYINT(1) DEFAULT 1,
+			after: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeTinyInt).
+				SetLength(model.NewLength("1")).
+				SetNullState(model.NullStateNone).
+				SetDefault("1", false),
+		},
+		{
+			// foo BOOL DEFAULT FALSE,
+			before: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeBool).
+				SetDefault("FALSE", false),
+			// foo TINYINT(1) DEFAULT 0,
+			after: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeTinyInt).
+				SetLength(model.NewLength("1")).
+				SetNullState(model.NullStateNone).
+				SetDefault("0", false),
+		},
+		{
+			// foo BOOLEAN
+			before: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeBoolean),
+			// foo TINYINT(1) DEFAULT NULL,
+			after: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeTinyInt).
+				SetLength(model.NewLength("1")).
+				SetNullState(model.NullStateNone).
+				SetDefault("NULL", false),
+		},
+		{
+			// foo BOOLEAN DEFAULT TRUE
+			before: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeBoolean).
+				SetDefault("TRUE", false),
+			// foo TINYINT(1) DEFAULT 1,
+			after: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeTinyInt).
+				SetLength(model.NewLength("1")).
+				SetNullState(model.NullStateNone).
+				SetDefault("1", false),
+		},
+		{
+			// foo BOOLEAN DEFAULT FALSE
+			before: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeBoolean).
+				SetDefault("FALSE", false),
+			// foo TINYINT(1) DEFAULT 0,
+			after: model.NewTableColumn("foo").
+				SetType(model.ColumnTypeTinyInt).
+				SetLength(model.NewLength("1")).
+				SetNullState(model.NullStateNone).
+				SetDefault("0", false),
+		},
 	} {
 		var buf bytes.Buffer
 		format.SQL(&buf, tc.before)

--- a/parser_test.go
+++ b/parser_test.go
@@ -228,20 +228,20 @@ primary key (id, c)
 		// BOOLEAN
 		{
 			Input:  "CREATE TABLE `test` (\n`valid` BOOLEAN not null default true\n);",
-			Expect: "CREATE TABLE `test` (\n`valid` BOOLEAN NOT NULL DEFAULT TRUE\n)",
+			Expect: "CREATE TABLE `test` (\n`valid` TINYINT (1) NOT NULL DEFAULT 1\n)",
 		},
 		{
 			Input:  "CREATE TABLE `test` (\n`valid` BOOLEAN not null default false\n);",
-			Expect: "CREATE TABLE `test` (\n`valid` BOOLEAN NOT NULL DEFAULT FALSE\n)",
+			Expect: "CREATE TABLE `test` (\n`valid` TINYINT (1) NOT NULL DEFAULT 0\n)",
 		},
 		// BOOL
 		{
 			Input:  "CREATE TABLE `test` (\n`valid` BOOL not null default true\n);",
-			Expect: "CREATE TABLE `test` (\n`valid` BOOL NOT NULL DEFAULT TRUE\n)",
+			Expect: "CREATE TABLE `test` (\n`valid` TINYINT (1) NOT NULL DEFAULT 1\n)",
 		},
 		{
 			Input:  "CREATE TABLE `test` (\n`valid` BOOL not null default false\n);",
-			Expect: "CREATE TABLE `test` (\n`valid` BOOL NOT NULL DEFAULT FALSE\n)",
+			Expect: "CREATE TABLE `test` (\n`valid` TINYINT (1) NOT NULL DEFAULT 0\n)",
 		},
 		// CREATE TABLE IF NOT EXISTS
 		{

--- a/scripts/check-diff.sh
+++ b/scripts/check-diff.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+UNTRACKED=$(git ls-files --others --exclude-standard)
+DIFF=$(git diff)
+
+st=0
+if [ ! -z "$DIFF" ]; then
+    echo "==== START OF DIFF FOUND ==="
+    echo ""
+    echo "$DIFF"
+    echo ""
+    echo "Above diff was found."
+    echo ""
+    echo "==== END OF DIFF FOUND ==="
+    echo ""
+    st=1
+fi
+
+if [ ! -z "$UNTRACKED" ]; then
+    echo "==== START OF UNTRACKED FILES FOUND ==="
+    echo ""
+    echo "$UNTRACKED"
+    echo ""
+    echo "Above untracked files were found."
+    echo ""
+    echo "==== END OF UNTRACKED FILES FOUND ==="
+    echo ""
+    st=1
+fi
+
+exit $st


### PR DESCRIPTION
* [x] model/table_column_test.go 入れすぎた気がしてるので消してもいいかも（ 結果として parser_test.go でやりたいことは網羅されてそう）
* [x] NativeLength() で bool, boolean の時に 1 を返してるけど、tinyint 自体はここでは扱えてない。 bool, boolean だったら強制的に tinyint(1) という感じにした方がわかりやすいかもしれない
* [x] synonyms のところ毎度順番が変わっちゃうのは map[string]string で定義してあるからかな。
* [x] デフォルト値が true, false だと 1, 0 に変換されるみたいなのでそれも追加。