### PR TITLE
generate files using newer stringer

### DIFF
--- a/model/index_kind_string_gen.go
+++ b/model/index_kind_string_gen.go
@@ -2,7 +2,7 @@
 
 package model
 
-import "fmt"
+import "strconv"
 
 const _IndexKind_name = "IndexKindInvalidIndexKindPrimaryKeyIndexKindNormalIndexKindUniqueIndexKindFullTextIndexKindSpatialIndexKindForeignKey"
 
@@ -10,7 +10,7 @@ var _IndexKind_index = [...]uint8{0, 16, 35, 50, 65, 82, 98, 117}
 
 func (i IndexKind) String() string {
 	if i < 0 || i >= IndexKind(len(_IndexKind_index)-1) {
-		return fmt.Sprintf("IndexKind(%d)", i)
+		return "IndexKind(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _IndexKind_name[_IndexKind_index[i]:_IndexKind_index[i+1]]
 }

--- a/model/index_type_string_gen.go
+++ b/model/index_type_string_gen.go
@@ -2,7 +2,7 @@
 
 package model
 
-import "fmt"
+import "strconv"
 
 const _IndexType_name = "IndexTypeNoneIndexTypeBtreeIndexTypeHash"
 
@@ -10,7 +10,7 @@ var _IndexType_index = [...]uint8{0, 13, 27, 40}
 
 func (i IndexType) String() string {
 	if i < 0 || i >= IndexType(len(_IndexType_index)-1) {
-		return fmt.Sprintf("IndexType(%d)", i)
+		return "IndexType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _IndexType_name[_IndexType_index[i]:_IndexType_index[i+1]]
 }

--- a/model/reference_match_string_gen.go
+++ b/model/reference_match_string_gen.go
@@ -2,7 +2,7 @@
 
 package model
 
-import "fmt"
+import "strconv"
 
 const _ReferenceMatch_name = "ReferenceMatchNoneReferenceMatchFullReferenceMatchPartialReferenceMatchSimple"
 
@@ -10,7 +10,7 @@ var _ReferenceMatch_index = [...]uint8{0, 18, 36, 57, 77}
 
 func (i ReferenceMatch) String() string {
 	if i < 0 || i >= ReferenceMatch(len(_ReferenceMatch_index)-1) {
-		return fmt.Sprintf("ReferenceMatch(%d)", i)
+		return "ReferenceMatch(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _ReferenceMatch_name[_ReferenceMatch_index[i]:_ReferenceMatch_index[i+1]]
 }

--- a/model/reference_option_string_gen.go
+++ b/model/reference_option_string_gen.go
@@ -2,7 +2,7 @@
 
 package model
 
-import "fmt"
+import "strconv"
 
 const _ReferenceOption_name = "ReferenceOptionNoneReferenceOptionRestrictReferenceOptionCascadeReferenceOptionSetNullReferenceOptionNoAction"
 
@@ -10,7 +10,7 @@ var _ReferenceOption_index = [...]uint8{0, 19, 42, 64, 86, 109}
 
 func (i ReferenceOption) String() string {
 	if i < 0 || i >= ReferenceOption(len(_ReferenceOption_index)-1) {
-		return fmt.Sprintf("ReferenceOption(%d)", i)
+		return "ReferenceOption(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _ReferenceOption_name[_ReferenceOption_index[i]:_ReferenceOption_index[i+1]]
 }


### PR DESCRIPTION
現時点での最新のstringerコマンドが生成するファイルが以前のものと異なっています。
去年の11月のコミットで fmt パッケージの代わりにstrconv パッケージを使う修正が入ったようです。

https://github.com/golang/tools/commit/bd4635fd25596cdd56c1fb399c53b351d1a81f2d#diff-0415b5286e4cf3e373f349d917e5e039

挙動は変わらないのですが、 `go generate` したときに余計な差分が出てしまって開発の邪魔になるかと思い、最新のstringerコマンドで生成した結果に置き換えました。
