### PR TITLE
Allow lines only containing a semicolon

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -185,11 +185,17 @@ LOOP:
 					ctx.advance()
 				}
 			}
+		case SEMICOLON:
+			// you could have statements where it's just empty, followed by a
+			// semicolon. These are just empty lines, so we just skip and go
+			// process the next statement
+			ctx.advance()
+			continue
 		case EOF:
 			ctx.advance()
 			break LOOP
 		default:
-			return nil, newParseError(ctx, t, "expected CREATE, COMMENT_IDENT or EOF")
+			return nil, newParseError(ctx, t, "expected CREATE, COMMENT_IDENT, SEMICOLON or EOF")
 		}
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -259,6 +259,19 @@ primary key (id, c)
 			Input:  "CREATE TABLE foo (id INT(10) NOT NULL) ENGINE = InnoDB, DEFAULT CHARACTER SET = utf8mb4",
 			Expect: "CREATE TABLE `foo` (\n`id` INT (10) NOT NULL\n) ENGINE = InnoDB, DEFAULT CHARACTER SET = utf8mb4",
 		},
+
+		// Comments (empty lines)
+		{
+			Input: `/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;`,
+			Expect: ``,
+		},
+		// Comments and statements mixed together
+		{
+			Input:  "/* hello, world*/;\nCREATE TABLE foo (\na int);\n/* hello, world again! */;\nCREATE TABLE bar (\nb int);",
+			Expect: "CREATE TABLE `foo` (\n`a` INT (11) DEFAULT NULL\n)CREATE TABLE `bar` (\n`b` INT (11) DEFAULT NULL\n)",
+		},
 	}
 
 	p := schemalex.New()


### PR DESCRIPTION
should fix #64

Basically, we allow empty statements. Comments are already ignored anyway. 