### PR TITLE
Add support for precision in DEFAULT NOW

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -269,6 +269,10 @@ primary key (id, c)
 		Input:  "create table `test_log` (`created_at` DATETIME default NOW())",
 		Expect: "CREATE TABLE `test_log` (\n`created_at` DATETIME DEFAULT NOW()\n)",
 	})
+	parse("TimestampPrecision", &Spec{
+		Input:  "CREATE TABLE `test` (`valid` TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))",
+		Expect: "CREATE TABLE `test` (`valid` TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))",
+	})
 }
 
 func testParse(t *testing.T, spec *Spec) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -263,15 +263,19 @@ primary key (id, c)
 			"  KEY `user_id_idx` (`user_id`),\r\n" +
 			"  CONSTRAINT `some_table__user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL ON UPDATE SET NULL\r\n" +
 			") ENGINE=InnoDB AUTO_INCREMENT=19 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;",
-		Expect: "CREATE TABLE `some_table` (\n`id` INT (10) UNSIGNED NOT NULL AUTO_INCREMENT,\n`user_id` VARCHAR (32) DEFAULT NULL,\n`context` JSON DEFAULT NULL,\n`created_at` DATETIME DEFAULT CURRENT_TIMESTAMP,\nPRIMARY KEY (`id`),\nINDEX `created_at` (`created_at` DESC),\nINDEX `user_id_idx` (`user_id`),\nINDEX `some_table__user_id` (`user_id`),\nCONSTRAINT `some_table__user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL ON UPDATE SET NULL\n) ENGINE = InnoDB, AUTO_INCREMENT = 19, DEFAULT CHARACTER SET = utf8mb4, DEFAULT COLLATE = utf8mb4_0900_ai_ci",
+		Expect: "CREATE TABLE `some_table` (\n`id` INT (10) UNSIGNED NOT NULL AUTO_INCREMENT,\n`user_id` VARCHAR (32) DEFAULT NULL,\n`context` JSON DEFAULT NULL,\n`created_at` DATETIME DEFAULT NOW(),\nPRIMARY KEY (`id`),\nINDEX `created_at` (`created_at` DESC),\nINDEX `user_id_idx` (`user_id`),\nINDEX `some_table__user_id` (`user_id`),\nCONSTRAINT `some_table__user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL ON UPDATE SET NULL\n) ENGINE = InnoDB, AUTO_INCREMENT = 19, DEFAULT CHARACTER SET = utf8mb4, DEFAULT COLLATE = utf8mb4_0900_ai_ci",
 	})
 	parse("DefaultNow", &Spec{
 		Input:  "create table `test_log` (`created_at` DATETIME default NOW())",
 		Expect: "CREATE TABLE `test_log` (\n`created_at` DATETIME DEFAULT NOW()\n)",
 	})
+	parse("CurrentTimestamp", &Spec{
+		Input:  "CREATE TABLE `test` (\n`valid` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP\n)",
+		Expect: "CREATE TABLE `test` (\n`valid` TIMESTAMP NOT NULL DEFAULT NOW()\n)",
+	})
 	parse("TimestampPrecision", &Spec{
-		Input:  "CREATE TABLE `test` (`valid` TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))",
-		Expect: "CREATE TABLE `test` (`valid` TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))",
+		Input:  "CREATE TABLE `test` (\n`valid` TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)\n)",
+		Expect: "CREATE TABLE `test` (\n`valid` TIMESTAMP (3) NOT NULL DEFAULT NOW(3)\n)",
 	})
 }
 


### PR DESCRIPTION
This PR adds supports for passing a precision to the time in the `DEFAULT` statement, for example:

```sql
CREATE TABLE `test` (
    `valid` TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
)
```

According [to the mysql documentation](https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_current-timestamp), `CURRENT_TIMESTAMP` is an alias for `NOW()`.

This PR also adds a transformation to normalize `CURRENT_TIMESTAMP` into `NOW`.