### PR TITLE
Update a log message in alterTables to show table name

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -262,7 +262,7 @@ func alterTables(ctx *diffCtx, dst io.Writer) (int64, error) {
 		for _, p := range procs {
 			n, err := p(alterCtx, &pbuf)
 			if err != nil {
-				return 0, errors.Wrap(err, `failed to generate alter table`)
+				return 0, errors.Wrapf(err, `failed to generate alter table from table '%s'`, id)
 			}
 
 			if buf.Len() > 0 && n > 0 {


### PR DESCRIPTION
I just updated a log message in [diff/diff.go](https://github.com/schemalex/schemalex/blob/master/diff/diff.go) file because I think it's more helpful to know error reason.

The error message in #56 becomes like this.
```
$ schemalex old.sql new.sql
2019/08/13 11:59:30 failed to produce diff: failed to generate alter table from table 'table#foo': can not drop index without name: index#a296fc5d3d6e4233fb3497fbbc5c0135991daa9f0cc1985873b5268f5f80284f
```
