### PR TITLE
Add double quote in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Examples:
   schemalex /path/to/file "mysql://user:password@tcp(host:port)/dbname?option=value"
 
 * Compare file in local git repository against local file
-  schemalex local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf /path/to/file
+  schemalex "local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf" /path/to/file
 
 * Compare schema from stdin against local file
 	.... | schemalex - /path/to/file

--- a/cmd/schemadiff/schemadiff.go
+++ b/cmd/schemadiff/schemadiff.go
@@ -49,7 +49,7 @@ Examples:
   schemadiff /path/to/file "mysql://user:password@tcp(host:port)/dbname?option=value"
 
 * Compare file in local git repository against local file
-  schemadiff local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf /path/to/file
+  schemadiff "local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf" /path/to/file
 
 * Compare schema from stdin against local file
 	.... | schemadiff - /path/to/file

--- a/cmd/schemalex/schemalex.go
+++ b/cmd/schemalex/schemalex.go
@@ -48,7 +48,7 @@ Examples:
   schemalex /path/to/file "mysql://user:password@tcp(host:port)/dbname?option=value"
 
 * Compare file in local git repository against local file
-  schemalex local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf /path/to/file
+  schemalex "local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf" /path/to/file
 
 * Compare schema from stdin against local file
 	.... | schemalex - /path/to/file

--- a/cmd/schemalint/schemalint.go
+++ b/cmd/schemalint/schemalint.go
@@ -52,7 +52,7 @@ Examples:
   schemalint "mysql://user:password@tcp(host:port)/dbname?option=value"
 
 * Lint a file in local git repository 
-  schemalint local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf
+  schemalint "local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf"
 
 * Lint schema from stdin against local file
 	.... | schemalint -


### PR DESCRIPTION
I just added `""` between `local-git...&commitish=deadbeaf` for each document because `&` causes background feature of shells (bash, tcsh, zsh,, etc).

Without `""`, fail to parse
```
bash-3.2$ schemalex local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf /path/to/file
[1] 16405
.
.
.
2019/08/13 13:21:37 wrong number of arguments
```

With `""`, succeed to parse
```
bash-3.2$ schemalex "local-git:///path/to/repo?file=foo.sql&commitish=deadbeaf" /path/to/file
2019/08/13 13:22:24 failed to retrieve schema from "from" source &{/path/to/repo foo.sql deadbeaf}: failed to run git command: [git show deadbeaf:foo.sql]: chdir /path/to/repo: no such file or directory
bash-3.2$
```