### PR TITLE
fix parse error mysql://user:@protocol(host:port)/dbname case at go 1.12.8

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -13,12 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testFile = ""
-
-func init() {
-	flag.StringVar(&testFile, "test-file", testFile, "path to test file")
-	flag.Parse()
-}
+var testFile = flag.String("test-file", "", "path to test file")
 
 type Spec struct {
 	Input  string
@@ -307,12 +302,13 @@ func testParse(t *testing.T, spec *Spec) {
 }
 
 func TestFile(t *testing.T) {
-	if testFile == "" {
+	flag.Parse()
+	if len(*testFile) == 0 {
 		t.Skipf("test-file is nil")
 		return
 	}
 
-	byt, err := ioutil.ReadFile(testFile)
+	byt, err := ioutil.ReadFile(*testFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -13,7 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testFile = flag.String("test-file", "", "path to test file")
+var testFile = ""
+
+func init() {
+	flag.StringVar(&testFile, "test-file", testFile, "path to test file")
+}
 
 type Spec struct {
 	Input  string
@@ -303,12 +307,12 @@ func testParse(t *testing.T, spec *Spec) {
 
 func TestFile(t *testing.T) {
 	flag.Parse()
-	if len(*testFile) == 0 {
+	if testFile == "" {
 		t.Skipf("test-file is nil")
 		return
 	}
 
-	byt, err := ioutil.ReadFile(*testFile)
+	byt, err := ioutil.ReadFile(testFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/source.go
+++ b/source.go
@@ -51,6 +51,13 @@ func NewSchemaSource(uri string) (SchemaSource, error) {
 		return NewReaderSource(os.Stdin), nil
 	}
 
+	if strings.HasPrefix(uri, "mysql://") {
+		// Treat the argument as a DSN for mysql.
+		// DSN is everything after "mysql://", so let's be lazy
+		// and use everything after the second slash
+		return NewMySQLSource(uri[8:]), nil
+	}
+
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, errors.Wrap(err, `failed to parse uri`)
@@ -61,11 +68,6 @@ func NewSchemaSource(uri string) (SchemaSource, error) {
 		// local-git:///path/to/dir?file=foo&commitish=bar
 		q := u.Query()
 		return NewLocalGitSource(u.Path, q.Get("file"), q.Get("commitish")), nil
-	case "mysql":
-		// Treat the argument as a DSN for mysql.
-		// DSN is everything after "mysql://", so let's be lazy
-		// and use everything after the second slash
-		return NewMySQLSource(uri[8:]), nil
 	case "file", "":
 		// Eh, no remote host, please
 		if u.Host != "" && u.Host != "localhost" {


### PR DESCRIPTION
## Description

Hi.

In Go 1.12.8, `url.Parse` return error when
uri is format of `mysql://user:@protocol(host:port)/dbname`.

This error cause by this changes.
https://github.com/golang/go/commit/3226f2d492963d361af9dfc6714ef141ba606713 

So,I Changed Code at parsing uri to divide mysql case and others.

Thank you.

## testcase
```
./schemalex "mysql://root:@tcp(localhost:3306)/dbname" db/schema.sql
2019/08/14 17:37:32 failed to create schema source for "from": failed to parse uri: parse mysql://root:@tcp(localhost:3306)/dbname: invalid port ":3306)" after host
```
