### PR TITLE
fix #84 `DROP INDEX PRIMARY KEY` -> `DROP PRIMARY KEY`

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -454,7 +454,7 @@ func dropTableIndexes(ctx *alterCtx, dst io.Writer) (int64, error) {
 			}
 			buf.WriteString("ALTER TABLE `")
 			buf.WriteString(ctx.from.Name())
-			buf.WriteString("` DROP INDEX PRIMARY KEY;")
+			buf.WriteString("` DROP PRIMARY KEY;")
 			continue
 		}
 

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -67,7 +67,7 @@ func TestDiff(t *testing.T) {
 		{
 			Before: "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT, PRIMARY KEY (`id`) );",
 			After:  "CREATE TABLE `fuga` ( `id` INTEGER NOT NULL AUTO_INCREMENT );",
-			Expect: "ALTER TABLE `fuga` DROP INDEX PRIMARY KEY;",
+			Expect: "ALTER TABLE `fuga` DROP PRIMARY KEY;",
 		},
 		// add primary key
 		{


### PR DESCRIPTION
Primary Key を変更時に作成される DDL を実行すると構文エラーとなるので修正いたしました。

## See
- MySQL: https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
- MariaDB: https://mariadb.com/kb/en/library/alter-table/
