### PR TITLE
fix: `FULLTEXT INDEX_NAME INDEX_COLUMNS` -> `FULLTEXT KEY INDEX_NAME …

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1108,6 +1108,11 @@ func (p *Parser) parseColumnIndexFullTextKey(ctx *parseCtx, index model.Index) e
 		return newParseError(ctx, t, "expected FULLTEXT")
 	}
 
+	ctx.skipWhiteSpaces()
+	if t := ctx.next(); t.Type != KEY {
+		return newParseError(ctx, t, "expected FULLTEXT")
+	}
+
 	// optional INDEX
 	ctx.skipWhiteSpaces()
 	if t := ctx.peek(); t.Type == INDEX {

--- a/parser_test.go
+++ b/parser_test.go
@@ -111,7 +111,7 @@ primary key (id, c)
 		Expect: "CREATE TABLE `hoge` (\n`id` BIGINT (20) UNSIGNED NOT NULL AUTO_INCREMENT,\n`c` VARCHAR (20) NOT NULL,\nFOREIGN KEY `fk_c` (`c`)\n)",
 	})
 	parse("WithFulltextIndex", &Spec{
-		Input:  "create table hoge (txt TEXT, fulltext ft_idx(txt))",
+		Input:  "create table hoge (txt TEXT, fulltext key ft_idx(txt))",
 		Expect: "CREATE TABLE `hoge` (\n`txt` TEXT,\nFULLTEXT INDEX `ft_idx` (`txt`)\n)",
 	})
 	parse("WithSimpleReferenceForeignKey", &Spec{


### PR DESCRIPTION
CREATE TABLE `test` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `name` varchar(20) NOT NULL,
  `mobile` varchar(15) NOT NULL,
  `note` varchar(1255) DEFAULT NULL,
  PRIMARY KEY (`id`),
  FULLTEXT KEY `note` (`note`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
fix FULLTEXT parse error

before: FULLTEXT INDEX_NAME INDEX_COLUMNS
now: FULLTEXT KEY INDEX_NAME INDEX_COLUMNS