### PR TITLE
escape values enclosed by single quotes

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -92,9 +92,7 @@ func formatTableOption(ctx *fmtCtx, option model.TableOption) error {
 	buf.WriteString(option.Key())
 	buf.WriteString(" = ")
 	if option.NeedQuotes() {
-		buf.WriteByte('\'')
-		buf.WriteString(option.Value())
-		buf.WriteByte('\'')
+		buf.WriteString(util.Singlequote(option.Value()))
 	} else {
 		buf.WriteString(option.Value())
 	}
@@ -216,9 +214,7 @@ func formatTableColumn(ctx *fmtCtx, col model.TableColumn) error {
 	case model.ColumnTypeEnum:
 		buf.WriteString(" (")
 		for enumValue := range col.EnumValues() {
-			buf.WriteByte('\'')
-			buf.WriteString(enumValue)
-			buf.WriteByte('\'')
+			buf.WriteString(util.Singlequote(enumValue))
 			buf.WriteByte(',')
 		}
 		buf.Truncate(buf.Len() - 1)
@@ -226,9 +222,7 @@ func formatTableColumn(ctx *fmtCtx, col model.TableColumn) error {
 	case model.ColumnTypeSet:
 		buf.WriteString(" (")
 		for setValue := range col.SetValues() {
-			buf.WriteByte('\'')
-			buf.WriteString(setValue)
-			buf.WriteByte('\'')
+			buf.WriteString(util.Singlequote(setValue))
 			buf.WriteByte(',')
 		}
 		buf.Truncate(buf.Len() - 1)
@@ -286,9 +280,7 @@ func formatTableColumn(ctx *fmtCtx, col model.TableColumn) error {
 	if col.HasDefault() {
 		buf.WriteString(" DEFAULT ")
 		if col.IsQuotedDefault() {
-			buf.WriteByte('\'')
-			buf.WriteString(col.Default())
-			buf.WriteByte('\'')
+			buf.WriteString(util.Singlequote(col.Default()))
 		} else {
 			buf.WriteString(col.Default())
 		}
@@ -309,9 +301,8 @@ func formatTableColumn(ctx *fmtCtx, col model.TableColumn) error {
 	}
 
 	if col.HasComment() {
-		buf.WriteString(" COMMENT '")
-		buf.WriteString(col.Comment())
-		buf.WriteByte('\'')
+		buf.WriteString(" COMMENT ")
+		buf.WriteString(util.Singlequote(col.Comment()))
 	}
 
 	if _, err := buf.WriteTo(ctx.dst); err != nil {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,7 +1,32 @@
 package util
 
+import (
+	"strings"
+)
+
 // Backquote surrounds the given string in backquotes
 func Backquote(s string) string {
 	// XXX Does this require escaping
 	return "`" + s + "`"
+}
+
+// Singlequote surrounds the given string in singlequotes
+func Singlequote(s string) string {
+	b := strings.Builder{}
+	b.Grow(len(s) + 2)
+	b.WriteRune('\'')
+	r := strings.NewReader(s)
+	for {
+		c, _, err := r.ReadRune()
+		if err != nil {
+			break
+		}
+		switch c {
+		case '\'', '\\':
+			b.WriteRune('\\')
+		}
+		b.WriteRune(c)
+	}
+	b.WriteRune('\'')
+	return b.String()
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,24 @@
+package util
+
+import "testing"
+
+func TestSinglequotes(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{
+			input: `hoge's comment`,
+			want:  `'hoge\'s comment'`,
+		},
+		{
+			input: `'\`,
+			want:  `'\'\\'`,
+		},
+	}
+	for _, tt := range tests {
+		got := Singlequote(tt.input)
+		if got != tt.want {
+			t.Errorf("want %q; got %q", tt.want, got)
+		}
+	}
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -2,7 +2,7 @@ package util
 
 import "testing"
 
-func TestSinglequotes(t *testing.T) {
+func TestSinglequote(t *testing.T) {
 	tests := []struct {
 		input, want string
 	}{


### PR DESCRIPTION
Fixes #97 

When formatting, all single-quoted values are escaped by `util.Singlequote` .