### PR TITLE
KEY may be after FULLTEXT keyword

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1108,9 +1108,9 @@ func (p *Parser) parseColumnIndexFullTextKey(ctx *parseCtx, index model.Index) e
 		return newParseError(ctx, t, "expected FULLTEXT")
 	}
 
-	// optional INDEX
+	// optional INDEX or KEY
 	ctx.skipWhiteSpaces()
-	if t := ctx.peek(); t.Type == INDEX {
+	if t := ctx.peek(); t.Type == INDEX || t.Type == KEY {
 		ctx.advance()
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -110,8 +110,16 @@ primary key (id, c)
 		Input:  "create table hoge ( `id` bigint unsigned not null auto_increment,\n `c` varchar(20) not null,\nFOREIGN KEY `fk_c` (`c`) )",
 		Expect: "CREATE TABLE `hoge` (\n`id` BIGINT (20) UNSIGNED NOT NULL AUTO_INCREMENT,\n`c` VARCHAR (20) NOT NULL,\nFOREIGN KEY `fk_c` (`c`)\n)",
 	})
-	parse("WithFulltextIndex", &Spec{
+	parse("WithFulltextIndex1", &Spec{
 		Input:  "create table hoge (txt TEXT, fulltext ft_idx(txt))",
+		Expect: "CREATE TABLE `hoge` (\n`txt` TEXT,\nFULLTEXT INDEX `ft_idx` (`txt`)\n)",
+	})
+	parse("WithFulltextIndex2", &Spec{
+		Input:  "create table hoge (txt TEXT, fulltext index ft_idx(txt))",
+		Expect: "CREATE TABLE `hoge` (\n`txt` TEXT,\nFULLTEXT INDEX `ft_idx` (`txt`)\n)",
+	})
+	parse("WithFulltextIndex3", &Spec{
+		Input:  "create table hoge (txt TEXT, fulltext key ft_idx(txt))",
 		Expect: "CREATE TABLE `hoge` (\n`txt` TEXT,\nFULLTEXT INDEX `ft_idx` (`txt`)\n)",
 	})
 	parse("WithSimpleReferenceForeignKey", &Spec{


### PR DESCRIPTION
related with https://github.com/schemalex/schemalex/pull/96

the following definitions of FULLTEXT index are all valid.

- `FULLTEXT index_name (key_part)`
- `FULLTEXT INDEX index_name (key_part)`
- `FULLTEXT KEY index_name (key_part)`

ref. https://dev.mysql.com/doc/refman/8.0/en/create-table.html

```
{FULLTEXT | SPATIAL} [INDEX | KEY] [index_name] (key_part,...)
```

but currently, schemalex fails to parse `FULLTEXT KEY index_name (key_part)`.